### PR TITLE
UIBULKED-289: Landing page is not cleared switching to "Query" tab after completed Bulk edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIBULKED-308](https://issues.folio.org/browse/UIBULKED-308) CSV: Cancel button doesn't stop file uploading
 * [UIBULKED-306](https://issues.folio.org/browse/UIBULKED-306) "Next" button remains disabled for a while after uploading modified file for Bulk edit (CSV approach)
 * [UIBULKED-287](https://issues.folio.org/browse/UIBULKED-287) "Something went wrong" error occurred clicking "Bulk edit" icon from the bulk edit In app form
+* [UIBULKED-289](https://issues.folio.org/browse/UIBULKED-289) Landing page is not cleared switching to "Query" tab after completed Bulk edit
 
 ## [3.0.5](https://github.com/folio-org/ui-bulk-edit/tree/v3.0.5) (2023-03-22)
 

--- a/src/components/BulkEditList/BulkEditListResult/BulkEditListResult.test.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditListResult.test.js
@@ -50,10 +50,20 @@ const renderBulkEditResult = (history, typeOfProgress = TYPE_OF_PROGRESS.INITIAL
 };
 
 describe('BulkEditListResult', () => {
-  it('displays empty message', () => {
+  it('displays empty message with identifier tab', () => {
     const history = createMemoryHistory();
 
-    history.push('/bulk-edit?capabilities=USERS');
+    history.push('/bulk-edit?capabilities=USERS&criteria=identifier');
+
+    renderBulkEditResult(history);
+
+    expect(screen.getByText(/list.result.emptyMessage/)).toBeVisible();
+  });
+
+  it('displays empty message with query tab', () => {
+    const history = createMemoryHistory();
+
+    history.push('/bulk-edit?capabilities=USERS&criteria=query');
 
     renderBulkEditResult(history);
 
@@ -63,7 +73,7 @@ describe('BulkEditListResult', () => {
   it('displays fileName field for initial preview', () => {
     const history = createMemoryHistory();
 
-    history.push('/bulk-edit/1/preview?fileName=Mock.csv&capabilities=USERS&step=UPLOAD');
+    history.push('/bulk-edit/1/preview?fileName=Mock.csv&capabilities=USERS&step=UPLOAD&criteria=identifier');
 
     renderBulkEditResult(history);
 
@@ -73,7 +83,7 @@ describe('BulkEditListResult', () => {
   it('displays title', () => {
     const history = createMemoryHistory();
 
-    history.push('/bulk-edit/1/progress?fileName=Mock.csv&capabilities=USERS');
+    history.push('/bulk-edit/1/progress?fileName=Mock.csv&capabilities=USERS&criteria=identifier');
 
     renderBulkEditResult(history, TYPE_OF_PROGRESS.INITIAL);
 
@@ -83,7 +93,7 @@ describe('BulkEditListResult', () => {
   it('displays processed title', () => {
     const history = createMemoryHistory();
 
-    history.push('/bulk-edit/1/progress?processedFileName=Mock.csv&capabilities=USERS');
+    history.push('/bulk-edit/1/progress?processedFileName=Mock.csv&capabilities=USERS&criteria=identifier');
 
     renderBulkEditResult(history, TYPE_OF_PROGRESS.PROCESSED);
 
@@ -93,7 +103,7 @@ describe('BulkEditListResult', () => {
   it('displays processed preview', () => {
     const history = createMemoryHistory();
 
-    history.push('/bulk-edit/1/preview?processedFileName=Mock.csv&capabilities=USERS');
+    history.push('/bulk-edit/1/preview?processedFileName=Mock.csv&capabilities=USERS&criteria=identifier');
 
     renderBulkEditResult(history, TYPE_OF_PROGRESS.PROCESSED);
 
@@ -103,7 +113,7 @@ describe('BulkEditListResult', () => {
   it('should render with no axe errors', async () => {
     const history = createMemoryHistory();
 
-    history.push('/bulk-edit/1/processed?processedFileName=Mock.csv&capabilities=USERS');
+    history.push('/bulk-edit/1/processed?processedFileName=Mock.csv&capabilities=USERS&criteria=identifier');
 
     renderBulkEditResult(history, TYPE_OF_PROGRESS.PROCESSED);
 

--- a/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
+++ b/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
@@ -33,7 +33,9 @@ const PreviewContainer = () => {
 
   const isInitial = step === EDITING_STEPS.UPLOAD;
 
-  if (criteria === CRITERIA.IDENTIFIER) {
+  if (criteria !== CRITERIA.IDENTIFIER) {
+    return <NoResultsMessage />;
+  } else {
     return isLoading ? (
       <div className={css.LoaderContainer}>
         <Loading />
@@ -47,7 +49,7 @@ const PreviewContainer = () => {
         isInitial={isInitial}
       />
     );
-  } else return <NoResultsMessage />;
+  }
 };
 
 export default PreviewContainer;

--- a/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
+++ b/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
@@ -5,10 +5,11 @@ import { useLocation, useParams } from 'react-router';
 import { Loading } from '@folio/stripes/components';
 
 import { useBulkOperationDetails } from '../../../../hooks/api';
-import { EDITING_STEPS } from '../../../../constants';
+import { CRITERIA, EDITING_STEPS } from '../../../../constants';
 import { Preview } from '../Preview/Preview';
 
 import css from '../../../BulkEdit.css';
+import { NoResultsMessage } from '../NoResultsMessage/NoResultsMessage';
 
 const PreviewContainer = () => {
   const intl = useIntl();
@@ -19,6 +20,7 @@ const PreviewContainer = () => {
   const fileUploadedName = search.get('fileName');
   const capabilities = search.get('capabilities')?.toLocaleLowerCase();
   const queryText = search.get('queryText');
+  const criteria = search.get('criteria');
 
   const { id } = useParams();
   const { bulkDetails, isLoading } = useBulkOperationDetails({ id, additionalQueryKeys: [step] });
@@ -31,19 +33,24 @@ const PreviewContainer = () => {
 
   const isInitial = step === EDITING_STEPS.UPLOAD;
 
-  return isLoading ? (
-    <div className={css.LoaderContainer}>
-      <Loading />
-    </div>
-  ) : (
-    <Preview
-      title={title}
-      id={id}
-      capabilities={capabilities}
-      bulkDetails={bulkDetails}
-      isInitial={isInitial}
-    />
-  );
+  switch (criteria) {
+    case CRITERIA.IDENTIFIER:
+      return isLoading ? (
+        <div className={css.LoaderContainer}>
+          <Loading />
+        </div>
+      ) : (
+        <Preview
+          title={title}
+          id={id}
+          capabilities={capabilities}
+          bulkDetails={bulkDetails}
+          isInitial={isInitial}
+        />
+      );
+    default:
+      return <NoResultsMessage />;
+  }
 };
 
 export default PreviewContainer;

--- a/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
+++ b/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
@@ -33,24 +33,21 @@ const PreviewContainer = () => {
 
   const isInitial = step === EDITING_STEPS.UPLOAD;
 
-  switch (criteria) {
-    case CRITERIA.IDENTIFIER:
-      return isLoading ? (
-        <div className={css.LoaderContainer}>
-          <Loading />
-        </div>
-      ) : (
-        <Preview
-          title={title}
-          id={id}
-          capabilities={capabilities}
-          bulkDetails={bulkDetails}
-          isInitial={isInitial}
-        />
-      );
-    default:
-      return <NoResultsMessage />;
-  }
+  if (criteria === CRITERIA.IDENTIFIER) {
+    return isLoading ? (
+      <div className={css.LoaderContainer}>
+        <Loading />
+      </div>
+    ) : (
+      <Preview
+        title={title}
+        id={id}
+        capabilities={capabilities}
+        bulkDetails={bulkDetails}
+        isInitial={isInitial}
+      />
+    );
+  } else return <NoResultsMessage />;
 };
 
 export default PreviewContainer;

--- a/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
+++ b/src/components/BulkEditList/BulkEditListResult/PreviewContainer/PreviewContainer.js
@@ -35,12 +35,14 @@ const PreviewContainer = () => {
 
   if (criteria !== CRITERIA.IDENTIFIER) {
     return <NoResultsMessage />;
-  } else {
-    return isLoading ? (
+  } else if (isLoading) {
+    return (
       <div className={css.LoaderContainer}>
         <Loading />
       </div>
-    ) : (
+    );
+  } else {
+    return (
       <Preview
         title={title}
         id={id}


### PR DESCRIPTION
Landing page is not cleared switching to "Query" tab after completed Bulk edit

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
[UIBULKED-289](https://issues.folio.org/browse/UIBULKED-289)
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.