### PR TITLE
UIBULKED-372: Bulk edit - Element IDs are not unique.

### DIFF
--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInAppPreviewModal/BulkEditInAppPreviewModal.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInAppPreviewModal/BulkEditInAppPreviewModal.js
@@ -44,7 +44,6 @@ const BulkEditInAppPreviewModal = ({
   const history = useHistory();
   const search = new URLSearchParams(history.location.search);
   const capabilities = search.get('capabilities');
-  const step = search.get('step');
   const { visibleColumns } = useContext(RootContext);
 
   const swwCallout = () => (
@@ -177,7 +176,7 @@ const BulkEditInAppPreviewModal = ({
             columnMapping={columnMapping}
             visibleColumns={visibleColumnKeys}
             maxHeight={300}
-            columnIdPrefix={step}
+            columnIdPrefix="in-app"
           />
         </>
       ) : <Preloader />}


### PR DESCRIPTION
[IBULKED-372](https://issues.folio.org/browse/UIBULKED-372)
In this PR we changed `prefix` for preview in modal, since `step` from url that was used before was the same for editing `in app`