### PR TITLE
UIBULKED-378: "Select location" can be selected for item's location, and the "Confirm changes" button will remain active.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [UIBULKED-356](https://issues.folio.org/browse/UIBULKED-356) Separate holdings notes by note type
 * [UIBULKED-349](https://issues.folio.org/browse/UIBULKED-349) Update Electronic access - URL relationship
 * [UIBULKED-347](https://issues.folio.org/browse/UIBULKED-347) Group holdings record properties using optgroup component.
+* [UIBULKED-378](https://issues.folio.org/browse/UIBULKED-378) "Select location" can be selected for item's location, and the "Confirm changes" button will remain active.
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
@@ -139,7 +139,7 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
     <>
       <LocationSelection
         value={actionValue}
-        onSelect={loc => onChange({ actionIndex, value: loc.id, fieldName: FIELD_VALUE_KEY })}
+        onSelect={loc => onChange({ actionIndex, value: loc?.id, fieldName: FIELD_VALUE_KEY })}
         placeholder={formatMessage({ id: 'ui-bulk-edit.layer.selectLocation' })}
         data-test-id={`textField-${actionIndex}`}
         aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.location' })}


### PR DESCRIPTION
[UIBULKED-378](https://issues.folio.org/browse/UIBULKED-378)
Here we make the button `commit changes` disabled when in `LocationSelection` selected `placeholder`. Previously it was available to commit changes with placeholder selected.

https://github.com/folio-org/ui-bulk-edit/assets/72550466/3697f197-944a-4f32-829d-1e8aab5af148



