### PR TITLE
UIBULKED-375: Localize alphabetical order of Bulk edit elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIBULKED-359](https://issues.folio.org/browse/UIBULKED-359) Update Electronic access - Materials specified.
 * [UIBULKED-378](https://issues.folio.org/browse/UIBULKED-378) "Select location" can be selected for item's location, and the "Confirm changes" button will remain active.
 * [UIBULKED-358](https://issues.folio.org/browse/UIBULKED-358) Update Electronic access - Link text.
+* [UIBULKED-375](https://issues.folio.org/browse/UIBULKED-375) Localize alphabetical order of Bulk edit elements.
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/BulkEditInApp.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/BulkEditInApp.js
@@ -14,6 +14,7 @@ import { ContentUpdatesForm } from './ContentUpdatesForm/ContentUpdatesForm';
 import { CAPABILITIES, getHoldingsOptions, getItemsOptions, getUserOptions } from '../../../../constants';
 import { useItemNotes } from '../../../../hooks/api/useItemNotes';
 import { useHoldingsNotes } from '../../../../hooks/api/useHoldingsNotes';
+import { sortAlphabetically } from '../../../../utils/sortAlphabetically';
 
 export const BulkEditInApp = ({
   onContentUpdatesChanged,
@@ -38,6 +39,7 @@ export const BulkEditInApp = ({
 
   const options = optionsMap[capabilities];
   const showContentUpdatesForm = options && !isItemNotesLoading && !isHoldingsNotesLoading;
+  const sortedOptions = sortAlphabetically(options, intl.formatMessage({ id:'ui-bulk-edit.options.placeholder' }));
 
   return (
     <>
@@ -50,7 +52,7 @@ export const BulkEditInApp = ({
         <BulkEditInAppTitle />
         {showContentUpdatesForm ? (
           <ContentUpdatesForm
-            options={options}
+            options={sortedOptions}
             onContentUpdatesChanged={onContentUpdatesChanged}
           />
         ) : (

--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ActionsRow.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ActionsRow.js
@@ -17,10 +17,21 @@ export const ActionsRow = ({ option, actions, onChange }) => {
   return actions.map((action, actionIndex) => {
     if (!action) return null;
 
+    const collator = new Intl.Collator();
+
+    const sortedActions = action.actionsList.sort((a, b) => {
+      if (a.label === formatMessage({ id: 'ui-bulk-edit.actions.placeholder' })) {
+        return -1;
+      } else if (b.label === formatMessage({ id: 'ui-bulk-edit.actions.placeholder' })) {
+        return 1;
+      } else {
+        return collator.compare(a.label, b.label);
+      }
+    });
     const renderOptionColumn = () => (
       <Col xs={2} sm={2}>
         <Select
-          dataOptions={action.actionsList}
+          dataOptions={sortedActions}
           value={action.name}
           onChange={(e) => onChange({ actionIndex, value: e.target.value, fieldName: ACTION_VALUE_KEY })}
           disabled={action.actionsList.length === 1}

--- a/src/utils/sortAlphabetically.js
+++ b/src/utils/sortAlphabetically.js
@@ -1,0 +1,9 @@
+export const sortAlphabetically = (array, placeholder) => array.sort((a, b) => {
+  if (a.label === placeholder) {
+    return -1;
+  } else if (placeholder) {
+    return 1;
+  } else {
+    return a.label.localeCompare(b.label);
+  }
+});

--- a/src/utils/sortAlphabetically.test.js
+++ b/src/utils/sortAlphabetically.test.js
@@ -1,0 +1,41 @@
+import { sortAlphabetically } from './sortAlphabetically';
+
+describe('sortAlphabetically', () => {
+  it('should sort the array alphabetically', () => {
+    const inputArray = [
+      { label: 'URL public note' },
+      { label: 'Link text' },
+      { label: 'Available' },
+    ];
+
+    const expectedOutput = [
+      { label: 'Available' },
+      { label: 'Link text' },
+      { label: 'URL public note' },
+    ];
+
+    const result = sortAlphabetically(inputArray, '');
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should handle a placeholder value and move it to the beginning', () => {
+    const inputArray = [
+      { label: 'URL public note' },
+      { label: 'Link text' },
+      { label: 'Available' },
+      { label: 'Placeholder' },
+    ];
+
+    const expectedOutput = [
+      { label: 'Placeholder' },
+      { label: 'URL public note' },
+      { label: 'Link text' },
+      { label: 'Available' },
+    ];
+
+    const result = sortAlphabetically(inputArray, 'Placeholder');
+
+    expect(result).toEqual(expectedOutput);
+  });
+});


### PR DESCRIPTION
[UIBULKED-375](https://issues.folio.org/browse/UIBULKED-375)
Here we added alphabetical sorting for options and action in bulk edit. We made two separate functions because in options we have optgroups

https://github.com/folio-org/ui-bulk-edit/assets/72550466/b2a98464-4589-476c-a7d4-ac284b2b5826

