### PR TITLE
UIBULKED-376: Separate Item circulation notes in different columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [UIBULKED-378](https://issues.folio.org/browse/UIBULKED-378) "Select location" can be selected for item's location, and the "Confirm changes" button will remain active.
 * [UIBULKED-358](https://issues.folio.org/browse/UIBULKED-358) Update Electronic access - Link text.
 * [UIBULKED-375](https://issues.folio.org/browse/UIBULKED-375) Localize alphabetical order of Bulk edit elements.
+* [UIBULKED-376](https://issues.folio.org/browse/UIBULKED-376) Separate Item circulation notes in different columns.
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -194,6 +194,8 @@
   "columns.ITEM.Tags": "Tags",
   "columns.ITEM.Last CheckIn": "Last check in",
   "columns.ITEM.Electronic Access": "Electronic access",
+  "columns.ITEM.Check In Notes": "Check in notes",
+  "columns.ITEM.Check Out Notes": "Check out notes",
 
   "columns.HOLDINGS_RECORD.Holdings record id": "Holdings ID",
   "columns.HOLDINGS_RECORD.Version": "Version",


### PR DESCRIPTION
[UIBULKED-376](https://issues.folio.org/browse/UIBULKED-376)
Here we just added translation keys and translations for them. The whole logic for building those columns was implemented early.