### PR TITLE
UIBULKED-390 Add Staff suppress option to Instance records edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [UIBULKED-363](https://issues.folio.org/browse/UIBULKED-363) Populate instance records identifiers drop-down
 * [UIBULKED-391](https://issues.folio.org/browse/UIBULKED-391) Changing value in dropdown, influences to change value in the other dropdown.
 * [UIBULKED-393](https://issues.folio.org/browse/UIBULKED-393) Add Inventory - instances filter to the Logs tab.
+* [UIBULKED-390](https://issues.folio.org/browse/UIBULKED-390) Add Staff suppress option to Instance records edits.
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/BulkEditInApp.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/BulkEditInApp.js
@@ -11,7 +11,13 @@ import {
 import { useLocation } from 'react-router';
 import { BulkEditInAppTitle } from './BulkEditInAppTitle/BulkEditInAppTitle';
 import { ContentUpdatesForm } from './ContentUpdatesForm/ContentUpdatesForm';
-import { CAPABILITIES, getHoldingsOptions, getItemsOptions, getUserOptions } from '../../../../constants';
+import {
+  CAPABILITIES,
+  getHoldingsOptions,
+  getInstanceOptions,
+  getItemsOptions,
+  getUserOptions
+} from '../../../../constants';
 import { useItemNotes } from '../../../../hooks/api/useItemNotes';
 import { useHoldingsNotes } from '../../../../hooks/api/useHoldingsNotes';
 import { sortAlphabetically } from '../../../../utils/sortAlphabetically';
@@ -35,6 +41,7 @@ export const BulkEditInApp = ({
     [CAPABILITIES.ITEM]: getItemsOptions(intl.formatMessage, itemNotes),
     [CAPABILITIES.USER]: getUserOptions(intl.formatMessage),
     [CAPABILITIES.HOLDING]: getHoldingsOptions(intl.formatMessage, holdingsNotes),
+    [CAPABILITIES.INSTANCE]: getInstanceOptions(intl.formatMessage),
   };
 
   const options = optionsMap[capabilities];

--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
@@ -193,6 +193,19 @@ export const getDefaultActions = (option, options, formatMessage) => {
           },
         ],
       };
+    case OPTIONS.STAFF_SUPPRESS_FROM_DISCOVERY:
+      return {
+        type: '',
+        actions: [
+          null,
+          {
+            actionsList: suppressDefaultActions,
+            controlType: () => CONTROL_TYPES.SUPPRESS_CHECKBOX,
+            [ACTION_VALUE_KEY]: suppressDefaultActions[0].value,
+            [FIELD_VALUE_KEY]: '',
+          },
+        ],
+      };
     case OPTIONS.PERMANENT_LOCATION:
       return locationRelatedDefaultActions;
     case OPTIONS.STATUS:

--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -10,6 +10,7 @@ export const OPTIONS = {
   TEMPORARY_LOCATION: 'TEMPORARY_LOCATION',
   PERMANENT_LOCATION: 'PERMANENT_LOCATION',
   SUPPRESS_FROM_DISCOVERY: 'SUPPRESS_FROM_DISCOVERY',
+  STAFF_SUPPRESS_FROM_DISCOVERY: 'STAFF_SUPPRESS_FROM_DISCOVERY',
   STATUS: 'STATUS',
   EXPIRATION_DATE: 'EXPIRATION_DATE',
   EMAIL_ADDRESS: 'EMAIL_ADDRESS',
@@ -263,6 +264,14 @@ export const getHoldingsOptions = (formatMessage, holdingsNotes = []) => [
   {
     value: OPTIONS.SUPPRESS_FROM_DISCOVERY,
     label: formatMessage({ id: 'ui-bulk-edit.layer.options.holdings.suppress' }),
+    disabled: false,
+  },
+];
+
+export const getInstanceOptions = (formatMessage) => [
+  {
+    value: OPTIONS.SUPPRESS_FROM_DISCOVERY,
+    label: formatMessage({ id: 'ui-bulk-edit.layer.options.holdings.staffSuppress' }),
     disabled: false,
   },
 ];

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -297,6 +297,7 @@
   "layer.options.holdings.temporaryLocation": "Temporary holdings location",
   "layer.options.holdings.permanentLocation": "Permanent holdings location",
   "layer.options.holdings.suppress": "Suppress from discovery",
+  "layer.options.holdings.staffSuppress": "Staff suppress",
   "layer.options.holdings.urlRelationship": "URL Relationship",
   "layer.options.holdings.linkText": "Link text",
   "layer.options.holdings.materialsSpecified": "Materials specified",


### PR DESCRIPTION
Provided the Staff suppress option on the bulk edit form for instance records. Ref [UIBULKED-390](https://issues.folio.org/browse/UIBULKED-390)

Test coverage will be increased in [UIBULKED-389](https://issues.folio.org/browse/UIBULKED-389), because main functionality is here.