### PR TITLE
UIBULKED-390 add placeholder to instance options

### DIFF
--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -270,6 +270,11 @@ export const getHoldingsOptions = (formatMessage, holdingsNotes = []) => [
 
 export const getInstanceOptions = (formatMessage) => [
   {
+    value: '',
+    label: formatMessage({ id: 'ui-bulk-edit.options.placeholder' }),
+    disabled: true,
+  },
+  {
     value: OPTIONS.STAFF_SUPPRESS,
     label: formatMessage({ id: 'ui-bulk-edit.layer.options.instances.staffSuppress' }),
     disabled: false,


### PR DESCRIPTION
Add missed placeholder for instance options. Ref: [UIBULKED-390](https://issues.folio.org/browse/UIBULKED-390)