### PR TITLE
UIBULKED-338 Add calculation of previews height based on content

### DIFF
--- a/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.test.js
+++ b/src/components/BulkEditList/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.test.js
@@ -10,6 +10,8 @@ import { ValuesColumn } from './ValuesColumn';
 import { useLoanTypes, usePatronGroup } from '../../../../../hooks/api';
 import { CAPABILITIES, CONTROL_TYPES } from '../../../../../constants';
 
+import '../../../../../../test/jest/__mock__';
+
 jest.mock('../../../../../hooks/api/useLoanTypes');
 jest.mock('../../../../../hooks/api/usePatronGroup');
 

--- a/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.js
@@ -35,6 +35,7 @@ const ErrorsAccordion = ({
   const [opened, setOpened] = useState(!!errorLength);
 
   const headLineTranslateKey = isInitial ? 'info' : 'infoProcessed';
+
   const headLine = (
     <FormattedMessage
       id={`ui-bulk-edit.list.errors.${headLineTranslateKey}`}
@@ -57,11 +58,9 @@ const ErrorsAccordion = ({
         label={<FormattedMessage id="ui-bulk-edit.list.errors.title" />}
       >
         <div className={css.errorAccordionInner}>
-          {!!errorLength && (
           <Headline size="medium" margin="small">
             {headLine}
           </Headline>
-          )}
           <MultiColumnList
             contentData={errors}
             columnMapping={columnMapping}

--- a/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.js
@@ -3,11 +3,11 @@ import { useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
   Accordion,
-  Col,
-  Row,
   MultiColumnList,
   Headline,
 } from '@folio/stripes/components';
+import { useState } from 'react';
+import css from '../Preview.css';
 
 const visibleColumns = ['key', 'message'];
 
@@ -31,7 +31,8 @@ const ErrorsAccordion = ({
   const location = useLocation();
   const fileName = new URLSearchParams(location.search).get('fileName');
   const errorLength = errors.length;
-  const maxHeight = window.innerHeight * 0.4;
+
+  const [opened, setOpened] = useState(!!errorLength);
 
   const headLineTranslateKey = isInitial ? 'info' : 'infoProcessed';
   const headLine = (
@@ -47,34 +48,30 @@ const ErrorsAccordion = ({
   );
 
   return (
-    <>
+    <div className={css.previewAccordion}>
       <Accordion
-        open={!!errorLength}
+        open={opened}
+        onToggle={() => {
+          setOpened(!opened);
+        }}
         label={<FormattedMessage id="ui-bulk-edit.list.errors.title" />}
       >
-
-        {!!errorLength && (
-          <Row>
-            <Col xs={12}>
-              <Headline size="medium" margin="small">
-                {headLine}
-              </Headline>
-            </Col>
-          </Row>
-        )}
-        <Row>
-          <Col xs={12}>
-            <MultiColumnList
-              contentData={errors}
-              columnMapping={columnMapping}
-              formatter={resultsFormatter}
-              visibleColumns={visibleColumns}
-              maxHeight={maxHeight}
-            />
-          </Col>
-        </Row>
+        <div className={css.errorAccordionInner}>
+          {!!errorLength && (
+          <Headline size="medium" margin="small">
+            {headLine}
+          </Headline>
+          )}
+          <MultiColumnList
+            contentData={errors}
+            columnMapping={columnMapping}
+            formatter={resultsFormatter}
+            visibleColumns={visibleColumns}
+            autosize
+          />
+        </div>
       </Accordion>
-    </>
+    </div>
   );
 };
 

--- a/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.test.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.test.js
@@ -1,4 +1,4 @@
-import { act, logDOM, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 import '../../../../../../test/jest/__mock__';

--- a/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.test.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/ErrorsAccordion/ErrorsAccordion.test.js
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { act, logDOM, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 import '../../../../../../test/jest/__mock__';
+import userEvent from '@testing-library/user-event';
 import { errorsPreview } from '../../../../../../test/jest/__mock__/fakeData';
 
 import ErrorsAccordion from './ErrorsAccordion';
@@ -14,7 +15,7 @@ const defaultProps = {
 };
 
 const renderPreviewAccordion = (history, props = defaultProps) => {
-  render(
+  return render(
     <MemoryRouter initialEntries={history}>
       <ErrorsAccordion {...props} />
     </MemoryRouter>,
@@ -40,5 +41,21 @@ describe('ErrorsAccordion', () => {
     expect(screen.getByText(/errors.infoProcessed/)).toBeVisible();
     expect(screen.getByText(/errors.table.code/)).toBeVisible();
     expect(screen.getByText(errorsPreview.errors[0].message)).toBeVisible();
+  });
+
+  it('should hide content when title was clicked', () => {
+    const mockHistory = ['/bulk-edit/1/preview'];
+
+    const { getByRole } = renderPreviewAccordion(mockHistory, { ...defaultProps, initial: false });
+
+    expect(screen.getByText(/errors.infoProcessed/)).toBeVisible();
+
+    const titleButton = getByRole('button', { name: /ui-bulk-edit.list.errors.title/ });
+
+    userEvent.click(titleButton);
+
+    waitFor(() => {
+      expect(screen.getByText(/errors.infoProcessed/)).not.toBeVisible();
+    });
   });
 });

--- a/src/components/BulkEditList/BulkEditListResult/Preview/Preview.css
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/Preview.css
@@ -1,0 +1,30 @@
+.previewContainer {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.previewAccordion {
+    flex-grow: 1;
+}
+
+.previewAccordion:first-child:has([aria-expanded="false"]) {
+    flex-grow: 0;
+}
+
+.previewAccordion > * {
+    height: 100%;
+}
+
+.previewAccordionInner {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+
+.errorAccordionInner {
+    display: grid;
+    height: calc(100% - 35px); /* 35px - height of the accordion header */
+    grid-template-columns: 1fr;
+    grid-template-rows: max-content auto;
+}

--- a/src/components/BulkEditList/BulkEditListResult/Preview/Preview.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/Preview.js
@@ -1,13 +1,13 @@
 import { FormattedMessage } from 'react-intl';
 import {
   Headline,
-  AccordionSet,
   AccordionStatus,
   MessageBanner,
 } from '@folio/stripes/components';
 import PropTypes from 'prop-types';
 import { useContext, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import css from './Preview.css';
 import { PreviewAccordion } from './PreviewAccordion';
 import { ErrorsAccordion } from './ErrorsAccordion';
 import { useErrorsPreview,
@@ -49,7 +49,8 @@ export const Preview = ({ id, title, isInitial, bulkDetails }) => {
 
   return (
     <AccordionStatus>
-      {!isInitial && (
+      <div className={css.previewContainer}>
+        {!isInitial && (
         <Headline size="large" margin="small">
           <MessageBanner type="success" contentClassName="SuccessBanner">
             <FormattedMessage
@@ -58,33 +59,36 @@ export const Preview = ({ id, title, isInitial, bulkDetails }) => {
             />
           </MessageBanner>
         </Headline>
-      )}
-      {title && (
+        )}
+        {title && (
         <Headline size="large" margin="medium">
           {title}
         </Headline>
-      )}
-      <AccordionSet>
-        {Boolean(contentData?.length) && (
-          <PreviewAccordion
-            isInitial={isInitial}
-            columns={columns}
-            contentData={contentData}
-            columnMapping={columnMapping}
-            visibleColumns={visibleColumns}
-            step={step}
-          />
         )}
-        {Boolean(errors?.length) && (
-          <ErrorsAccordion
-            errors={errors}
-            entries={totalCount}
-            matched={countOfRecords}
-            countOfErrors={countOfErrors}
-            isInitial={isInitial}
-          />
-        )}
-      </AccordionSet>
+        <div className={css.previewAccordionInner}>
+          {Boolean(contentData?.length) && (
+            <PreviewAccordion
+              isInitial={isInitial}
+              columns={columns}
+              contentData={contentData}
+              columnMapping={columnMapping}
+              visibleColumns={visibleColumns}
+              step={step}
+            />
+          )}
+
+          {Boolean(errors?.length) && (
+            <ErrorsAccordion
+              errors={errors}
+              entries={totalCount}
+              matched={countOfRecords}
+              countOfErrors={countOfErrors}
+              isInitial={isInitial}
+            />
+          )}
+        </div>
+
+      </div>
     </AccordionStatus>
   );
 };

--- a/src/components/BulkEditList/BulkEditListResult/Preview/PreviewAccordion/PreviewAccordion.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/PreviewAccordion/PreviewAccordion.js
@@ -3,40 +3,36 @@ import { PropTypes } from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import {
   Accordion,
-  Col,
-  Row,
   MultiColumnList,
 } from '@folio/stripes/components';
 import { PREVIEW_COLUMN_WIDTHS } from '../../../../PermissionsModal/constants/lists';
 import { getVisibleColumnsKeys } from '../../../../../utils/helpers';
+import css from '../Preview.css';
 
 
 const PreviewAccordion = ({ contentData, columnMapping, visibleColumns, isInitial, step }) => {
   const translationKey = isInitial ? 'title' : 'titleChanged';
-  const maxHeight = window.innerHeight * 0.4;
 
   const accordionLabel = <FormattedMessage id={`ui-bulk-edit.list.preview.${translationKey}`} />;
 
   const visibleColumnKeys = getVisibleColumnsKeys(visibleColumns);
 
   return (
-    <Accordion
-      label={accordionLabel}
-    >
-      <Row>
-        <Col xs={12}>
-          <MultiColumnList
-            striped
-            contentData={contentData}
-            columnMapping={columnMapping}
-            visibleColumns={visibleColumnKeys}
-            maxHeight={maxHeight}
-            columnIdPrefix={step}
-            columnWidths={PREVIEW_COLUMN_WIDTHS}
-          />
-        </Col>
-      </Row>
-    </Accordion>
+    <div className={css.previewAccordion}>
+      <Accordion
+        label={accordionLabel}
+      >
+        <MultiColumnList
+          striped
+          contentData={contentData}
+          columnMapping={columnMapping}
+          visibleColumns={visibleColumnKeys}
+          columnIdPrefix={step}
+          columnWidths={PREVIEW_COLUMN_WIDTHS}
+          autosize
+        />
+      </Accordion>
+    </div>
   );
 };
 

--- a/src/utils/sortAlphabetically.js
+++ b/src/utils/sortAlphabetically.js
@@ -1,4 +1,4 @@
-export const sortAlphabetically = (array, placeholder) => array.sort((a, b) => {
+export const sortAlphabetically = (array, placeholder) => array?.sort((a, b) => {
   const collator = new Intl.Collator();
 
   if (a.label === placeholder) {

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -2,3 +2,4 @@ import './stripesComponents.mock';
 import './stripesCore.mock';
 import './stripesSmartComponents.mock';
 import './reactIntl.mock';
+import './resizeObserver.mock';

--- a/test/jest/__mock__/resizeObserver.mock.js
+++ b/test/jest/__mock__/resizeObserver.mock.js
@@ -1,0 +1,5 @@
+window.ResizeObserver = jest.fn().mockImplementation(() => ({
+  observe: jest.fn(),
+  unobserve: jest.fn(),
+  disconnect: jest.fn(),
+}));


### PR DESCRIPTION
Currently, all previews (errors and matched elements) were limited to 40% of the available viewport height. This is not entirely correct, after this PR we will have:
- if there are only errors, then it takes up the entire available height
- if only the record preview, it occupies the entire available height
- if both, the free space is divided in half between them

Please see attached images:
Only errors

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/8c22ecc8-3cb8-436d-8256-6a6e457c26b9)

Only preview of records

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/0975280a-6d50-486f-9f28-3088ef75abf6)

Preview of records + errors

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/71ef06b9-ef8d-437e-bcbd-361a93836071)

