### PR TITLE
UIBULKED-403 add missed permissions and clean state between tabs change

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,13 @@
           "inventory-storage.item-note-types.item.get",
           "inventory-storage.call-number-types.item.get",
           "inventory-storage.call-number-types.item.get",
-          "inventory-storage.electronic-access-relationships.item.get"
+          "inventory-storage.electronic-access-relationships.item.get",
+          "fqm.entityTypes.collection.get",
+          "fqm.entityTypes.item.get",
+          "fqm.entityTypes.item.columnValues.get",
+          "fqm.query.async.results.get",
+          "fqm.query.async.post",
+          "fqm.query.async.delete"
         ],
         "visible": true
       }

--- a/src/components/BulkEditList/BulkEditListFilters/BulkEditListFilters.js
+++ b/src/components/BulkEditList/BulkEditListFilters/BulkEditListFilters.js
@@ -151,9 +151,12 @@ export const BulkEditListFilters = ({
   };
 
   const handleCriteriaChange = (value) => {
-    setFilters(prev => ({ ...prev, criteria: value }));
+    const newFilterValue = { capabilities: null, recordTypes: null, criteria: value };
+
+    setFilters(prev => ({ ...prev, ...newFilterValue }));
+
     history.replace({
-      search: buildSearch({ criteria: value }, location.search),
+      search: buildSearch(newFilterValue, location.search),
     });
   };
 

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -89,6 +89,7 @@
   "list.errors.table.message": "Reason for error",
 
   "uploaderBtnText": "or choose file",
+  "uploaderSubTitle": "Select a file with record identifiers",
   "uploaderSubTitle.empty": "Select a file with record identifiers",
   "uploaderSubTitle.item": "Select a file with record identifiers",
   "uploaderSubTitle.user": "Select a file with record identifiers",


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/461 adding permissions was missed. Also it's required clean state between tab changes, to avoid invalid parameters to query-builder.