### PR TITLE
UIBULKED-367 Logs - Provide a link to file with identifiers of the records affected by query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [UIBULKED-407](https://issues.folio.org/browse/UIBULKED-407) When selecting action "Find" in Bulk Edit, the last dropdown on the row moves to the right.
 * [UIBULKED-403](https://issues.folio.org/browse/UIBULKED-403) Integrate query-plugin with bulk-edit API.
 * [UIBULKED-246](https://issues.folio.org/browse/UIBULKED-246) Enabling Build query button on Query tab.
+* [UIBULKED-367](https://issues.folio.org/browse/UIBULKED-367) Logs - Provide a link to file with identifiers of the records affected by query.
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/src/components/BulkEditList/BulkEditListFilters/BulkEditListFilters.js
+++ b/src/components/BulkEditList/BulkEditListFilters/BulkEditListFilters.js
@@ -265,18 +265,15 @@ export const BulkEditListFilters = ({
   );
 
   const renderListSelect = () => (
-    <>
-      {JSON.stringify(capabilities)}
-      <ListSelect
-        value={recordIdentifier}
-        disabled={getIsDisabledByPerm(capabilities,
-          isSelectIdentifiersDisabled,
-          hasAnyUserWithBulkPerm,
-          hasAnyInventoryWithInAppView)}
-        onChange={handleRecordIdentifierChange}
-        capabilities={capabilities}
-      />
-    </>
+    <ListSelect
+      value={recordIdentifier}
+      disabled={getIsDisabledByPerm(capabilities,
+        isSelectIdentifiersDisabled,
+        hasAnyUserWithBulkPerm,
+        hasAnyInventoryWithInAppView)}
+      onChange={handleRecordIdentifierChange}
+      capabilities={capabilities}
+    />
   );
 
   const renderListFileUploader = () => (

--- a/src/components/BulkEditList/BulkEditListFilters/BulkEditListFilters.js
+++ b/src/components/BulkEditList/BulkEditListFilters/BulkEditListFilters.js
@@ -151,7 +151,7 @@ export const BulkEditListFilters = ({
   };
 
   const handleCriteriaChange = (value) => {
-    const newFilterValue = { capabilities: null, recordTypes: null, criteria: value };
+    const newFilterValue = { capabilities: '', recordTypes: '', criteria: value };
 
     setFilters(prev => ({ ...prev, ...newFilterValue }));
 
@@ -265,15 +265,18 @@ export const BulkEditListFilters = ({
   );
 
   const renderListSelect = () => (
-    <ListSelect
-      value={recordIdentifier}
-      disabled={getIsDisabledByPerm(capabilities,
-        isSelectIdentifiersDisabled,
-        hasAnyUserWithBulkPerm,
-        hasAnyInventoryWithInAppView)}
-      onChange={handleRecordIdentifierChange}
-      capabilities={capabilities}
-    />
+    <>
+      {JSON.stringify(capabilities)}
+      <ListSelect
+        value={recordIdentifier}
+        disabled={getIsDisabledByPerm(capabilities,
+          isSelectIdentifiersDisabled,
+          hasAnyUserWithBulkPerm,
+          hasAnyInventoryWithInAppView)}
+        onChange={handleRecordIdentifierChange}
+        capabilities={capabilities}
+      />
+    </>
   );
 
   const renderListFileUploader = () => (

--- a/src/components/BulkEditList/BulkEditListResult/Preview/Preview.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/Preview.js
@@ -15,7 +15,7 @@ import {
   useRecordsPreview
 } from '../../../../hooks/api';
 
-import { PAGINATION_CONFIG } from '../../../../constants';
+import { EDITING_STEPS, PAGINATION_CONFIG } from '../../../../constants';
 import { usePagination } from '../../../../hooks/usePagination';
 import { useBulkOperationStats } from '../../../../hooks/useBulkOperationStats';
 
@@ -24,6 +24,8 @@ export const Preview = ({ id, title, isInitial, bulkDetails }) => {
   const search = new URLSearchParams(location.search);
   const step = search.get('step');
   const capabilities = search.get('capabilities');
+
+  const totalRecords = step === EDITING_STEPS.COMMIT ? bulkDetails?.processedNumOfRecords : bulkDetails?.matchedNumOfRecords;
 
   const {
     countOfRecords,
@@ -70,7 +72,7 @@ export const Preview = ({ id, title, isInitial, bulkDetails }) => {
         <div className={css.previewAccordionOuter}>
           {Boolean(contentData?.length) && (
             <PreviewAccordion
-              totalRecords={bulkDetails?.matchedNumOfRecords}
+              totalRecords={totalRecords}
               isInitial={isInitial}
               columns={columns}
               contentData={contentData}

--- a/src/components/BulkEditLogs/BulkEditLogsActions/BulkEditLogsActions.js
+++ b/src/components/BulkEditLogs/BulkEditLogsActions/BulkEditLogsActions.js
@@ -16,10 +16,13 @@ import {
 } from '@folio/stripes/components';
 import { FormattedMessage } from 'react-intl';
 import { QUERY_KEY_DOWNLOAD_LOGS, useFileDownload } from '../../../hooks/api';
-import { CAPABILITIES, linkNamesMap } from '../../../constants';
+import { APPROACHES, CAPABILITIES, linkNamesMap } from '../../../constants';
 import { useBulkPermissions } from '../../../hooks';
+import { getFileName } from '../../../utils/getFileName';
 
 const BulkEditLogsActions = ({ item }) => {
+  const fileNamePostfix = item.approach === APPROACHES.QUERY ? `.${item.approach}` : '';
+
   const {
     hasUsersViewPerms,
     hasInventoryInstanceViewPerms,
@@ -34,7 +37,7 @@ const BulkEditLogsActions = ({ item }) => {
       fileContentType: linkNamesMap[triggeredFile],
     },
     onSuccess: data => {
-      saveAs(new Blob([data]), item[triggeredFile].split('/')[1]);
+      saveAs(new Blob([data]), getFileName(item, triggeredFile));
       setTriggeredFile(null);
     },
   });
@@ -76,7 +79,7 @@ const BulkEditLogsActions = ({ item }) => {
             onClick={() => onLoadFile(file)}
           >
             <Icon icon="download">
-              <FormattedMessage id={`ui-bulk-edit.logs.actions.${file}`} />
+              <FormattedMessage id={`ui-bulk-edit.logs.actions.${file}${fileNamePostfix}`} />
             </Icon>
           </Button>
         ))}

--- a/src/utils/getFileName.js
+++ b/src/utils/getFileName.js
@@ -1,0 +1,15 @@
+import { APPROACHES, getFormattedFilePrefixDate } from '../constants';
+
+export const getFileName = (item, triggeredFile) => {
+  if (item.approach === APPROACHES.QUERY) {
+    return {
+      linkToTriggeringCsvFile: `Query-${item.id}.csv`,
+      linkToMatchedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Matched-Records-Query-${item.id}.csv`,
+      linkToModifiedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Updates-Preview-Query-${item.id}.csv`,
+      linkToCommittedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Changed-Records-Query-${item.id}.csv`,
+      linkToCommittedRecordsErrorsCsvFile: `${getFormattedFilePrefixDate()}-Committing-changes-Errors-Query-${item.id}.csv`
+    }[triggeredFile];
+  }
+
+  return item[triggeredFile].split('/')[1];
+};

--- a/src/utils/getFileName.js
+++ b/src/utils/getFileName.js
@@ -1,7 +1,7 @@
-import { APPROACHES, getFormattedFilePrefixDate } from '../constants';
+import { getFormattedFilePrefixDate } from '../constants';
 
 export const getFileName = (item, triggeredFile) => {
-  if (item.approach === APPROACHES.QUERY) {
+  if (item.fqlQueryId) {
     return {
       linkToTriggeringCsvFile: `Query-${item.id}.csv`,
       linkToMatchedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Matched-Records-Query-${item.id}.csv`,

--- a/src/utils/getFileName.test.js
+++ b/src/utils/getFileName.test.js
@@ -1,5 +1,4 @@
 import { getFileName } from './getFileName';
-import { APPROACHES } from '../constants';
 
 jest.mock('./date', () => ({
   getFormattedFilePrefixDate: jest.fn(() => 'mockedDate'),
@@ -7,21 +6,21 @@ jest.mock('./date', () => ({
 
 describe('getFileName', () => {
   it('should return the correct file name for Query approach - linkToTriggeringCsvFile', () => {
-    const item = { approach: APPROACHES.QUERY, id: 123 };
+    const item = { fqlQueryId: '111', id: 123 };
     const triggeredFile = 'linkToTriggeringCsvFile';
     const result = getFileName(item, triggeredFile);
     expect(result).toBe('Query-123.csv');
   });
 
   it('should return the correct file name for Query approach - linkToMatchedRecordsCsvFile', () => {
-    const item = { approach: APPROACHES.QUERY, id: 123 };
+    const item = { fqlQueryId: '111', id: 123 };
     const triggeredFile = 'linkToMatchedRecordsCsvFile';
     const result = getFileName(item, triggeredFile);
     expect(result).toBe('mockedDate-Matched-Records-Query-123.csv');
   });
 
   it('should return the correct file name for non-Query approach', () => {
-    const item = { approach: APPROACHES.IN_APP, linkToTriggeringCsvFile: 'somePath/someFile.csv' };
+    const item = { fqlQueryId: null, linkToTriggeringCsvFile: 'somePath/someFile.csv' };
     const triggeredFile = 'linkToTriggeringCsvFile';
     const result = getFileName(item, triggeredFile);
     expect(result).toBe('someFile.csv');

--- a/src/utils/getFileName.test.js
+++ b/src/utils/getFileName.test.js
@@ -1,0 +1,29 @@
+import { getFileName } from './getFileName';
+import { APPROACHES } from '../constants';
+
+jest.mock('./date', () => ({
+  getFormattedFilePrefixDate: jest.fn(() => 'mockedDate'),
+}));
+
+describe('getFileName', () => {
+  it('should return the correct file name for Query approach - linkToTriggeringCsvFile', () => {
+    const item = { approach: APPROACHES.QUERY, id: 123 };
+    const triggeredFile = 'linkToTriggeringCsvFile';
+    const result = getFileName(item, triggeredFile);
+    expect(result).toBe('Query-123.csv');
+  });
+
+  it('should return the correct file name for Query approach - linkToMatchedRecordsCsvFile', () => {
+    const item = { approach: APPROACHES.QUERY, id: 123 };
+    const triggeredFile = 'linkToMatchedRecordsCsvFile';
+    const result = getFileName(item, triggeredFile);
+    expect(result).toBe('mockedDate-Matched-Records-Query-123.csv');
+  });
+
+  it('should return the correct file name for non-Query approach', () => {
+    const item = { approach: APPROACHES.IN_APP, linkToTriggeringCsvFile: 'somePath/someFile.csv' };
+    const triggeredFile = 'linkToTriggeringCsvFile';
+    const result = getFileName(item, triggeredFile);
+    expect(result).toBe('someFile.csv');
+  });
+});

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -392,6 +392,7 @@
   "logs.actions.linkToModifiedRecordsCsvFile": "File with the preview of proposed changes",
   "logs.actions.linkToCommittedRecordsCsvFile": "File with updated records",
   "logs.actions.linkToCommittedRecordsErrorsCsvFile": "File with errors encountered when committing the changes",
+  "logs.actions.linkToTriggeringCsvFile.QUERY": "File with identifiers of the records affected by bulk update",
   "logs.filter.title.status": "Statuses",
   "logs.filter.title.capability": "Record types",
   "logs.filter.title.types": "Bulk operation type",


### PR DESCRIPTION
In scope of [UIBULKED-367](https://issues.folio.org/browse/UIBULKED-367) it's required rename uploaded files name based on specific format (only for query approach)