### PR TITLE
UIBULKED-384 Change delimiters to split string

### DIFF
--- a/src/components/BulkEditList/BulkEditListResult/Preview/ElectronicAccessTable/ElectronicAccessTable.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/ElectronicAccessTable/ElectronicAccessTable.js
@@ -4,13 +4,8 @@ import { ELECTRONIC_ACCESS_HEAD_TITLES } from '../../../../PermissionsModal/cons
 import css from './ElectronicAcess.css';
 
 export const ElectronicAccessTable = ({ value }) => {
-  const tableBodyRows = value?.split('|')
-    .map(row => {
-      const cells = row.split(';');
-      const [uri, linkText, materialsSpecified, publicNote, relationship] = cells;
-
-      return [relationship, uri, linkText, materialsSpecified, publicNote];
-    });
+  const tableBodyRows = value?.split('\u001f|')
+    .map(row => row.split('\u001f;'));
 
   return (
     <table className={css.ElectronicAccess}>

--- a/src/components/BulkEditList/BulkEditListResult/Preview/ElectronicAccessTable/ElectronicAccessTable.test.js
+++ b/src/components/BulkEditList/BulkEditListResult/Preview/ElectronicAccessTable/ElectronicAccessTable.test.js
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { ElectronicAccessTable } from './ElectronicAccessTable';
 
 
-const testValue = 'https://search.proquest.com/publication/1396348;test;1.2012 -;via ProQuest, the last 12 months are not available due to an embargo;Resource';
+const testValue = 'https://search.proquest.com/publication/1396348\u001f;test\u001f;1.2012 -\u001f;via ProQuest, the last 12 months are not available due to an embargo\u001f;Resource';
 describe('ElectronicAccessTable', () => {
   it('renders table headers correctly', () => {
     const { getByText } = render(<ElectronicAccessTable value={testValue} />);
@@ -21,7 +21,7 @@ describe('ElectronicAccessTable', () => {
 
   it('renders table body rows correctly', () => {
     const { getByText } = render(<ElectronicAccessTable value={testValue} />);
-    const tableBodyRows = testValue.split('|').map(row => row.split(';'));
+    const tableBodyRows = testValue.split('\u001f|').map(row => row.split('\u001f;'));
 
     tableBodyRows.forEach(row => {
       row.forEach(cell => {


### PR DESCRIPTION
In scope of BE ticket [MODEXPW-457](https://folio-org.atlassian.net/browse/MODEXPW-457), delimiters for string was changed. Frontend have to be updated as well.
After changes everything is working as expected: 
![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/fe02dbf4-73f2-44d4-bedb-cf3482e0964d)
