### PR TITLE
UIBULKED-411 Prevent reset of identifier

### DIFF
--- a/src/components/BulkEditList/BulkEditListSidebar/LogsTab/LogsTab.js
+++ b/src/components/BulkEditList/BulkEditListSidebar/LogsTab/LogsTab.js
@@ -38,6 +38,7 @@ export const LogsTab = () => {
   const {
     step,
     initialFileName,
+    identifier,
     capabilities,
     queryRecordType
   } = useSearchParams();
@@ -49,6 +50,7 @@ export const LogsTab = () => {
   ] = useLocationFilters({
     initialFilter: {
       step,
+      identifier,
       capabilities,
       queryRecordType,
       criteria: CRITERIA.LOGS,


### PR DESCRIPTION
Prevent reset of identifier when clicking "Reset all" button on logs tab.