### PR TITLE
UIBULKED-437: Remove ISBN and ISSN from the list of instance records identifiers drop-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [UIBULKED-434](https://folio-org.atlassian.net/browse/UIBULKED-434) Electronic access table is resized incorrectly when to go through pagination and back.
 * [UIBULKED-451](https://issues.folio.org/browse/UIBULKED-451) Set Maximum Limit for Bulk Edit.
 * [UIBULKED-416](https://issues.folio.org/browse/UIBULKED-416) Refactoring of bulk-edit preview components.
+* [UIBULKED-437](https://issues.folio.org/browse/UIBULKED-437) Remove ISBN and ISSN from the list of instance records identifiers drop-down
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -135,14 +135,15 @@ export const identifierOptions = {
       value: IDENTIFIERS.HRID,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.instance.instanceHRID',
     },
-    {
-      value: IDENTIFIERS.ISBN,
-      label: 'ui-bulk-edit.list.filters.recordIdentifier.instance.instanceISBN',
-    },
-    {
-      value: IDENTIFIERS.ISSN,
-      label: 'ui-bulk-edit.list.filters.recordIdentifier.instance.instanceISSN',
-    },
+    // It's commented in scope of story UIBULKED-437
+    // {
+    //   value: IDENTIFIERS.ISBN,
+    //   label: 'ui-bulk-edit.list.filters.recordIdentifier.instance.instanceISBN',
+    // },
+    // {
+    //   value: IDENTIFIERS.ISSN,
+    //   label: 'ui-bulk-edit.list.filters.recordIdentifier.instance.instanceISSN',
+    // },
   ],
   '': [
     {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-43
We hided `ISBN` and `ISNN` options from select