### PR TITLE
UIBULKED-453: Disable "run query" button if test query has not results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [UIBULKED-434](https://folio-org.atlassian.net/browse/UIBULKED-434) Electronic access table is resized incorrectly when to go through pagination and back.
 * [UIBULKED-451](https://issues.folio.org/browse/UIBULKED-451) Set Maximum Limit for Bulk Edit.
 * [UIBULKED-416](https://issues.folio.org/browse/UIBULKED-416) Refactoring of bulk-edit preview components.
+* [UIBULKED-453](https://folio-org.atlassian.net/browse/UIBULKED-453) Disable "run query" button if test query has not results.
 
 ## [4.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.0.0) (2023-10-12)
 

--- a/src/components/BulkEditPane/BulkEditListSidebar/QueryTab/QueryTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/QueryTab/QueryTab.js
@@ -123,6 +123,7 @@ export const QueryTab = () => {
         onQueryRunSuccess={onQueryRunSuccess}
         runQueryDataSource={runQueryDataSource}
         recordsLimit={100000}
+        canRunEmptyQuery={false}
       />
     </>
   );


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-453
We added recently added prop to `plugin` to make the button `run query` disabled if `test query` returned an empty result