### PR TITLE
UIBULKED-441 Bulk edit form enhancements - part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-bulk-edit
 
 ## In progress
+* [UIBULKED-441](https://issues.folio.org/browse/UIBULKED-441) Bulk edit form enhancements - part 1.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/BulkEditInApp.css
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/BulkEditInApp.css
@@ -1,21 +1,36 @@
 @import "@folio/stripes-components/lib/variables";
 
 .row {
-  background-color: var(--color-fill);
-  line-height: var(--line-height);
-  margin: 0;
-  box-sizing: border-box;
-  padding-top: 20px;
-  justify-content: flex-end;
+    background-color: var(--color-fill);
+    line-height: var(--line-height);
+    margin: 0;
+    box-sizing: border-box;
+    justify-content: flex-end;
+}
+
+.row [class^="repeatableFieldList"] {
+    margin: 0;
 }
 
 .iconButtonWrapper {
     margin-left: auto;
-    padding-right: 10px;
+    padding: 5px 10px;
+    min-width: 70px;
+    border-left: 1px solid var(--color-border-p2);
+    text-align: right;
 }
 
 .additionalParameters {
     display: flex;
     align-items: center;
     gap: 10px;
+}
+
+.borderRight {
+    border-right: 1px solid var(--color-border-p2);
+}
+
+.column {
+    padding-top: 5px;
+    padding-bottom: 5px;
 }

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ActionsRow.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ActionsRow.js
@@ -11,6 +11,7 @@ import { ACTION_VALUE_KEY } from './helpers';
 import { ValuesColumn } from './ValuesColumn';
 import { AdditionalActionParameters } from './AdditionalActionParameters';
 import { sortAlphabeticallyActions } from '../../../../../utils/sortAlphabetically';
+import css from '../BulkEditInApp.css';
 
 export const ActionsRow = ({ option, actions, onChange }) => {
   const { formatMessage } = useIntl();
@@ -20,7 +21,7 @@ export const ActionsRow = ({ option, actions, onChange }) => {
 
     const sortedActions = sortAlphabeticallyActions(action.actionsList, formatMessage({ id: 'ui-bulk-edit.actions.placeholder' }));
     const renderOptionColumn = () => (
-      <Col xs={2} sm={2}>
+      <Col xs={2} sm={2} className={css.column}>
         <Select
           dataOptions={sortedActions}
           value={action.name}
@@ -28,6 +29,8 @@ export const ActionsRow = ({ option, actions, onChange }) => {
           disabled={action.actionsList?.length === 1}
           data-testid={`select-actions-${actionIndex}`}
           aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.actionsSelect' })}
+          marginBottom0
+          dirty={action.name}
         />
       </Col>
     );

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
@@ -279,12 +279,14 @@ export const ContentUpdatesForm = ({
       renderField={(field, index) => {
         return (
           <Row data-testid={`row-${index}`}>
-            <Col xs={3} sm={3}>
+            <Col xs={3} sm={3} className={`${css.column} ${css.borderRight}`}>
               <Select
                 value={field.option}
                 onChange={(e) => handleOptionChange(e, index)}
                 data-testid={`select-option-${index}`}
                 aria-label={`select-option-${index}`}
+                dirty={field.option}
+                marginBottom0
               >
                 {renderOptions(groupByCategory(field.options))}
               </Select>

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
@@ -248,7 +248,7 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
   );
 
   return (
-    <Col xs={2} sm={2} className={`${css.column}`}>
+    <Col xs={2} sm={2} className={css.column}>
       {renderTextField()}
       {renderTextArea()}
       {renderPatronGroupSelect()}

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
@@ -29,6 +29,7 @@ import { usePreselectedValue } from '../../../../../hooks/usePreselectedValue';
 import { useHoldingsNotes } from '../../../../../hooks/api/useHoldingsNotes';
 import { useElectronicAccessRelationships } from '../../../../../hooks/api/useElectronicAccess';
 import { useSearchParams } from '../../../../../hooks/useSearchParams';
+import css from '../BulkEditInApp.css';
 
 export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option }) => {
   const { formatMessage } = useIntl();
@@ -81,6 +82,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
       onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
       data-testid={`input-email-${actionIndex}`}
       aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.textField' })}
+      marginBottom0
+      dirty={actionValue}
     />
   );
 
@@ -90,6 +93,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
       onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
       data-testid={`input-textarea-${actionIndex}`}
       aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.textArea' })}
+      marginBottom0
+      dirty={actionValue}
     />
   );
 
@@ -121,6 +126,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
         onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
         data-testid={`select-patronGroup-${actionIndex}`}
         aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.patronGroupSelect' })}
+        marginBottom0
+        dirty={actionValue}
       />
     );
   };
@@ -134,6 +141,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
       data-testid={`dataPicker-experation-date-${actionIndex}`}
       backendDateStandard={BASE_DATE_FORMAT}
       aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.date' })}
+      marginBottom0
+      dirty={actionValue}
     />
   );
 
@@ -145,6 +154,7 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
         placeholder={formatMessage({ id: 'ui-bulk-edit.layer.selectLocation' })}
         data-test-id={`textField-${actionIndex}`}
         aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.location' })}
+        dirty={actionValue}
       />
       <LocationLookup
         marginBottom0
@@ -164,6 +174,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
       onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
       data-testid={`select-statuses-${actionIndex}`}
       aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.statusSelect' })}
+      marginBottom0
+      dirty={actionValue}
     />
   );
 
@@ -176,6 +188,7 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
       placeholder={formatMessage({ id: 'ui-bulk-edit.layer.selectLoanType' })}
       dataOptions={loanTypes}
       aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.loanTypeSelect' })}
+      dirty={actionValue}
     />
   );
 
@@ -188,6 +201,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
         onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
         dataOptions={sortedHoldingsNotes}
         aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.loanTypeSelect' })}
+        marginBottom0
+        dirty={action.value}
       />)
       :
       (<Select
@@ -201,6 +216,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
         })}
         dataOptions={sortedNotes}
         aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.loanTypeSelect' })}
+        marginBottom0
+        dirty={actionValue}
       />)
   );
 
@@ -212,6 +229,8 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
     onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
     dataOptions={duplicateNoteOptions}
     aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.loanTypeSelect' })}
+    marginBottom0
+    dirty={actionValue}
   />
   );
 
@@ -223,11 +242,13 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
       onChange={e => onChange({ actionIndex, value: e.target.value, fieldName: FIELD_VALUE_KEY })}
       dataOptions={accessRelationshipsWithPlaceholder}
       aria-label={formatMessage({ id: 'ui-bulk-edit.ariaLabel.urlRelationshipSelect' })}
+      marginBottom0
+      dirty={actionValue}
     />
   );
 
   return (
-    <Col xs={2} sm={2}>
+    <Col xs={2} sm={2} className={`${css.column}`}>
       {renderTextField()}
       {renderTextArea()}
       {renderPatronGroupSelect()}


### PR DESCRIPTION
In scope of this PR was added first part of enhancements related to bulk-edit in-app form:

- added borders between columns
- added `dirty` property, to hightlight filled fields

Refs: [UIBULKED-441](https://folio-org.atlassian.net/browse/UIBULKED-441)

Before 

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/36cf5465-77ae-425a-b960-3d8a38c2b183)

After (borders and dirty fields are present)

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/f995f09d-eb62-4892-a4b2-e2c437e1eb6b)
 