### PR TITLE
UIBULKED-467 File is not downloaded to local machine when "Actions" menu is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [UIBULKED-441](https://issues.folio.org/browse/UIBULKED-441) Bulk edit form enhancements - part 1.
 * [UIBULKED-442](https://issues.folio.org/browse/UIBULKED-442) Bulk edit form enhancements - part 2.
 * [UIBULKED-465](https://issues.folio.org/browse/UIBULKED-465) Local approach - Incorrect numbers of changed records and errors are displayed on Confirmation screen
+* [UIBULKED-467](https://issues.folio.org/browse/UIBULKED-467) File is not downloaded to local machine when "Actions" menu is closed
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.js
@@ -1,15 +1,15 @@
+import React, { useContext, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
-import { saveAs } from 'file-saver';
+
 import {
   Button,
   Icon,
   TextField,
 } from '@folio/stripes/components';
 import { CheckboxFilter } from '@folio/stripes/smart-components';
-import React, { useContext, useState } from 'react';
 import { Preloader } from '@folio/stripes-data-transfer-components';
-import css from './ActionMenuGroup/ActionMenuGroup.css';
+
 import { ActionMenuGroup } from './ActionMenuGroup/ActionMenuGroup';
 import {
   APPROACHES,
@@ -18,25 +18,23 @@ import {
   EDITING_STEPS,
   JOB_STATUSES,
   BULK_VISIBLE_COLUMNS,
-  FILE_SEARCH_PARAMS,
-  FILE_TO_LINK,
 } from '../../constants';
 import {
   useBulkPermissions,
   usePathParams,
+  useSearchParams
 } from '../../hooks';
 import { RootContext } from '../../context/RootContext';
-import {
-  QUERY_KEY_DOWNLOAD_ACTION_MENU,
-  useBulkOperationDetails,
-  useFileDownload
-} from '../../hooks/api';
+import { useBulkOperationDetails } from '../../hooks/api';
 import { getVisibleColumnsKeys } from '../../utils/helpers';
-import { useSearchParams } from '../../hooks/useSearchParams';
+
+import css from './ActionMenuGroup/ActionMenuGroup.css';
+
 
 const BulkEditActionMenu = ({
   onEdit,
   onToggle,
+  setFileInfo,
 }) => {
   const intl = useIntl();
   const perms = useBulkPermissions();
@@ -58,26 +56,10 @@ const BulkEditActionMenu = ({
   const { id } = usePathParams('/bulk-edit/:id');
   const { bulkDetails, isLoading } = useBulkOperationDetails({ id, additionalQueryKeys: [step] });
 
-  const [fileInfo, setFileInfo] = useState(null);
-
   const hasEditPerm = (hasHoldingsInventoryEdit && currentRecordType === CAPABILITIES.HOLDING)
       || (hasItemInventoryEdit && currentRecordType === CAPABILITIES.ITEM)
       || (hasUserEditInAppPerm && currentRecordType === CAPABILITIES.USER)
       || (hasInstanceInventoryEdit && currentRecordType === CAPABILITIES.INSTANCE);
-
-
-  useFileDownload({
-    queryKey: QUERY_KEY_DOWNLOAD_ACTION_MENU,
-    enabled: !!fileInfo,
-    id,
-    fileInfo: {
-      fileContentType: FILE_SEARCH_PARAMS[fileInfo?.param],
-    },
-    onSuccess: data => {
-      saveAs(new Blob([data]), fileInfo?.bulkDetails[FILE_TO_LINK[fileInfo?.param]].split('/')[1]);
-      setFileInfo(null);
-    },
-  });
 
   const { countOfRecords, visibleColumns, setVisibleColumns } = useContext(RootContext);
   const columns = visibleColumns || [];
@@ -212,6 +194,7 @@ const BulkEditActionMenu = ({
 BulkEditActionMenu.propTypes = {
   onToggle: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,
+  setFileInfo: PropTypes.func.isRequired,
 };
 
 export default BulkEditActionMenu;

--- a/src/hooks/api/useFileDownload.js
+++ b/src/hooks/api/useFileDownload.js
@@ -9,6 +9,7 @@ export const useFileDownload = ({
   id,
   fileInfo,
   onSuccess,
+  onSettled,
   queryKey,
   ...queryProps
 }) => {
@@ -22,6 +23,7 @@ export const useFileDownload = ({
       }).blob(),
       enabled: !!fileInfo,
       onSuccess,
+      onSettled,
       ...queryProps,
     },
   );

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -3,3 +3,4 @@ export * from './useLocationFilters';
 export * from './useBulkPermissions';
 export * from './useLogsQueryParams';
 export * from './useDerivativeModification';
+export * from './useSearchParams';


### PR DESCRIPTION
After this PR is merged, we will fix the problem where when downloading large files/when the Internet is slow, and user close the Action menu before content downloads - then the file will still be downloaded, since the save handler has been raised to a higher level.

Ref:  [UIBULKED-467](https://folio-org.atlassian.net/browse/UIBULKED-467)
