### PR TITLE
UIBULKED-472: "Uploading" is displayed instead of "Committing" on Confirmation screen if to reload the page

### DIFF
--- a/src/components/BulkEditPane/BulkEditListSidebar/IdentifierTab/IdentifierTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/IdentifierTab/IdentifierTab.js
@@ -36,7 +36,6 @@ export const IdentifierTab = () => {
     isFileUploaded,
     setIsFileUploaded,
     setVisibleColumns,
-    setInAppCommitted,
   } = useContext(RootContext);
 
   const {
@@ -102,12 +101,10 @@ export const IdentifierTab = () => {
 
     setIsFileUploaded(false);
     setVisibleColumns(null);
-    setInAppCommitted(false);
   }, [
     history,
     setIsFileUploaded,
     setVisibleColumns,
-    setInAppCommitted
   ]);
 
   const handleCapabilityChange = (e) => {
@@ -125,7 +122,6 @@ export const IdentifierTab = () => {
 
     setVisibleColumns(null);
     setIsFileUploaded(false);
-    setInAppCommitted(false);
   };
 
   const handleDragEnter = () => {

--- a/src/components/BulkEditPane/BulkEditListSidebar/QueryTab/QueryTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/QueryTab/QueryTab.js
@@ -30,7 +30,6 @@ export const QueryTab = () => {
   const {
     setIsFileUploaded,
     setVisibleColumns,
-    setInAppCommitted,
   } = useContext(RootContext);
 
   const { recordTypes } = useRecordTypes();
@@ -87,7 +86,6 @@ export const QueryTab = () => {
 
     setIsFileUploaded(false);
     setVisibleColumns(null);
-    setInAppCommitted(false);
   };
 
   const onQueryRunSuccess = ({ id }) => {

--- a/src/components/BulkEditPane/BulkEditPane.js
+++ b/src/components/BulkEditPane/BulkEditPane.js
@@ -46,7 +46,6 @@ export const BulkEditPane = () => {
   const [contentUpdates, setContentUpdates] = useState(null);
   const [visibleColumns, setVisibleColumns] = useState(null);
   const [confirmedFileName, setConfirmedFileName] = useState(null);
-  const [inAppCommitted, setInAppCommitted] = useState(false);
   const [fileInfo, setFileInfo] = useState(null);
 
   const { isActionMenuShown } = useBulkPermissions();
@@ -72,8 +71,6 @@ export const BulkEditPane = () => {
     visibleColumns,
     setVisibleColumns,
     confirmedFileName,
-    inAppCommitted,
-    setInAppCommitted,
     isFileUploaded,
     setIsFileUploaded,
     setIsBulkEditLayerOpen,
@@ -81,7 +78,6 @@ export const BulkEditPane = () => {
     countOfRecords,
     visibleColumns,
     confirmedFileName,
-    inAppCommitted,
     isFileUploaded
   ]);
 
@@ -108,7 +104,6 @@ export const BulkEditPane = () => {
     setVisibleColumns,
     filtersTab,
     setIsBulkEditLayerOpen,
-    setInAppCommitted,
   });
 
   const handleBulkEditLayerOpen = useCallback(() => {
@@ -129,7 +124,6 @@ export const BulkEditPane = () => {
   const handleChangesCommitted = useCallback(() => {
     handlePreviewModalClose();
     handleBulkEditLayerClose();
-    setInAppCommitted(true);
   }, [handleBulkEditLayerClose, handlePreviewModalClose]);
 
   const handleStartBulkEdit = (approach) => {

--- a/src/components/shared/ProgressBar/ProgressBar.js
+++ b/src/components/shared/ProgressBar/ProgressBar.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useParams } from 'react-router';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -6,15 +6,13 @@ import { Icon, Loading } from '@folio/stripes/components';
 import { useShowCallout } from '@folio/stripes-acq-components';
 
 import { useBulkOperationDetails } from '../../../hooks/api';
-import { ERRORS, JOB_STATUSES } from '../../../constants';
+import { EDITING_STEPS, ERRORS, JOB_STATUSES } from '../../../constants';
 import { getBulkOperationStep } from './utils';
 import css from './ProgressBar.css';
-import { RootContext } from '../../../context/RootContext';
 import { useSearchParams } from '../../../hooks/useSearchParams';
 
 export const ProgressBar = () => {
   const callout = useShowCallout();
-  const { inAppCommitted } = useContext(RootContext);
   const intl = useIntl();
   const {
     processedFileName,
@@ -76,7 +74,7 @@ export const ProgressBar = () => {
           size="small"
         />
         <div className={css.progressBarTitleText}>
-          {inAppCommitted ?
+          {step === EDITING_STEPS.UPLOAD ?
             <FormattedMessage
               id="ui-bulk-edit.progressBar.committing"
             />
@@ -93,7 +91,7 @@ export const ProgressBar = () => {
         </div>
         <div className={css.progressBarLineStatus}>
           <span>
-            {inAppCommitted ?
+            {step === EDITING_STEPS.UPLOAD ?
               <FormattedMessage id="ui-bulk-edit.progresssBar.processing" />
               :
               <FormattedMessage id="ui-bulk-edit.progresssBar.retrieving" />

--- a/src/components/shared/ProgressBar/ProgressBar.test.js
+++ b/src/components/shared/ProgressBar/ProgressBar.test.js
@@ -5,11 +5,10 @@ import { render, screen } from '@testing-library/react';
 
 import { runAxeTest } from '@folio/stripes-testing';
 
-import { ERRORS, JOB_STATUSES } from '../../../constants';
+import { EDITING_STEPS, ERRORS, JOB_STATUSES } from '../../../constants';
 import { useBulkOperationDetails } from '../../../hooks/api';
 
 import { ProgressBar } from './ProgressBar';
-import { RootContext } from '../../../context/RootContext';
 
 jest.mock('../../../hooks/api', () => ({
   useBulkOperationDetails: jest.fn(),
@@ -17,12 +16,10 @@ jest.mock('../../../hooks/api', () => ({
 
 const history = createMemoryHistory();
 
-const renderProgressBar = (inAppCommitted = false) => {
+const renderProgressBar = (step = '') => {
   render(
-    <MemoryRouter initialEntries={['/bulk-edit/1/preview?processedFileName=some.scv&criteria=identifier&progress=identifier']}>
-      <RootContext.Provider value={{ inAppCommitted }}>
-        <ProgressBar />
-      </RootContext.Provider>
+    <MemoryRouter initialEntries={[`/bulk-edit/1/preview?processedFileName=some.scv&criteria=identifier&progress=identifier&step=${step}`]}>
+      <ProgressBar />
     </MemoryRouter>,
   );
 };
@@ -69,7 +66,7 @@ describe('ProgressBar', () => {
   it('should render with text after in app committing', async () => {
     useBulkOperationDetails.mockReturnValue({ bulkDetails: bulkOperation });
 
-    renderProgressBar(true);
+    renderProgressBar(EDITING_STEPS.UPLOAD);
 
     expect(screen.getByText(/progresssBar.processing/)).toBeVisible();
   });

--- a/src/hooks/useResetAppState.js
+++ b/src/hooks/useResetAppState.js
@@ -11,7 +11,6 @@ export const useResetAppState = ({
   setCountOfRecords,
   filtersTab,
   setIsBulkEditLayerOpen,
-  setInAppCommitted
 }) => {
   const history = useHistory();
   const queryClient = useQueryClient();
@@ -49,7 +48,6 @@ export const useResetAppState = ({
       });
 
       setIsBulkEditLayerOpen(false);
-      setInAppCommitted(false);
     }
   }, [
     history,
@@ -58,7 +56,6 @@ export const useResetAppState = ({
     setCountOfRecords,
     filtersTab.logsTab,
     setIsBulkEditLayerOpen,
-    setInAppCommitted,
     queryClient,
   ]);
 };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-472
Here we removed logic based on `state` and made it based on `query params` for `ProgressBar.js`