### PR TITLE
UIBULKED-470 "Apply to all holdings records", "Apply to all items records" checkboxes set to default value when delete other row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [UIBULKED-471](https://folio-org.atlassian.net/browse/UIBULKED-471) Rename "Find" to "Find (full field search)".
 * [UIBULKED-476](https://folio-org.atlassian.net/browse/UIBULKED-476) Remove local QueryClientProvider from bulk edit.
 * [UIBULKED-478](https://folio-org.atlassian.net/browse/UIBULKED-478) Update permissions related to export manager module.
+* [UIBULKED-470](https://folio-org.atlassian.net/browse/UIBULKED-470) "Apply to all holdings records", "Apply to all items records" checkboxes set to default value when delete other row.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/BulkEditInApp.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/BulkEditInApp.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useEffect, useMemo, useState } from 'react';
+import uniqueId from 'lodash/uniqueId';
 
 import {
   Headline,
@@ -21,7 +22,7 @@ import {
 import { useItemNotes } from '../../../../hooks/api/useItemNotes';
 import { useHoldingsNotes } from '../../../../hooks/api/useHoldingsNotes';
 import { sortAlphabetically } from '../../../../utils/sortAlphabetically';
-import { useSearchParams } from '../../../../hooks/useSearchParams';
+import { useSearchParams } from '../../../../hooks';
 import { getDefaultActions } from './ContentUpdatesForm/helpers';
 
 export const BulkEditInApp = ({
@@ -52,6 +53,7 @@ export const BulkEditInApp = ({
 
   const fieldTemplate = useMemo(() => {
     return ({
+      id: uniqueId(),
       options,
       option: options[0].value,
       actionsDetails: getDefaultActions({

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import noop from 'lodash/noop';
+import uniqueId from 'lodash/uniqueId';
 
 import {
   IconButton,
@@ -26,7 +27,7 @@ import {
   getExtraActions,
 } from './helpers';
 import { groupByCategory } from '../../../../../utils/helpers';
-import { useSearchParams } from '../../../../../hooks/useSearchParams';
+import { useSearchParams } from '../../../../../hooks';
 
 export const ContentUpdatesForm = ({
   onContentUpdatesChanged,
@@ -169,6 +170,7 @@ export const ContentUpdatesForm = ({
   const handleAdd = () => {
     const filteredFields = getFilteredFields([...fields, {
       ...fieldTemplate,
+      id: uniqueId(),
       actionsDetails: {
         type: null,
         actions: [],
@@ -261,6 +263,7 @@ export const ContentUpdatesForm = ({
 
   return (
     <RepeatableField
+      getFieldUniqueKey={(field) => field.id}
       fields={fields}
       className={css.row}
       onAdd={noop}


### PR DESCRIPTION
After this PR merged all fields will have unique ids what will prevent reset state after mount, if action name wasn't changed. Refs: [UIBULKED-470](https://folio-org.atlassian.net/browse/UIBULKED-470)

Before remove
![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/ac14fe1b-9310-485e-9f80-976af9bf96d1)

After remove item in repetable fields, checkbox is still checked (in prev implementation it was reseted)
![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/930039b0-4bb8-40d8-9f78-e6e20e244dc9)
