### PR TITLE
UIBULKED-458 Show staff only checkbox for checkin/checkout notes

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
@@ -285,6 +285,7 @@ export const getDefaultActions = ({
             },
             [ACTION_VALUE_KEY]: noteDuplicateDefaultActions[0].value,
             [FIELD_VALUE_KEY]: '',
+            [ACTION_PARAMETERS_KEY]: getActionParameters(opt, capability),
           },
         ],
       };

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.test.js
@@ -656,6 +656,13 @@ describe('ContentUpdatesForm helpers', () => {
                     name: '',
                     [ACTION_VALUE_KEY]: '',
                     [FIELD_VALUE_KEY]: '',
+                    [ACTION_PARAMETERS_KEY]: [
+                      {
+                        key: PARAMETERS_KEYS.STAFF_ONLY,
+                        value: false,
+                        onlyForActions: [ACTIONS.ADD_TO_EXISTING]
+                      },
+                    ]
                   },
                 ],
               }),

--- a/src/constants/actionParameters.js
+++ b/src/constants/actionParameters.js
@@ -25,8 +25,11 @@ export const getActionParameters = (option, capability) => {
     }
   }
 
-  if ((option === OPTIONS.ITEM_NOTE && capability === CAPABILITIES.ITEM) ||
-    (option === OPTIONS.HOLDINGS_NOTE && capability === CAPABILITIES.HOLDING)) {
+  const showForSpecificItemNotes = [OPTIONS.ITEM_NOTE, OPTIONS.CHECK_IN_NOTE, OPTIONS.CHECK_OUT_NOTE].includes(option)
+    && capability === CAPABILITIES.ITEM;
+  const showForSpecificHoldingNotes = option === OPTIONS.HOLDINGS_NOTE && capability === CAPABILITIES.HOLDING;
+
+  if (showForSpecificItemNotes || showForSpecificHoldingNotes) {
     return [
       {
         key: PARAMETERS_KEYS.STAFF_ONLY,


### PR DESCRIPTION
In scope op PR https://github.com/folio-org/ui-bulk-edit/pull/520 supporting for checkin and checout notes weren't added. 

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/73a68b84-c48c-4731-be23-bfa54ef52658)