### PR TITLE
UIBULKED-479 Extend User search in User lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [UIBULKED-470](https://folio-org.atlassian.net/browse/UIBULKED-470) "Apply to all holdings records", "Apply to all items records" checkboxes set to default value when delete other row.
 * [UIBULKED-458](https://folio-org.atlassian.net/browse/UIBULKED-458) Bulk Edit Actions for Item Notes - Staff Only for Added Notes.
 * [UIBULKED-459](https://folio-org.atlassian.net/browse/UIBULKED-459) Bulk Edit Actions for Holdings Notes - Staff Only for Added Notes.
+* [UIBULKED-479](https://folio-org.atlassian.net/browse/UIBULKED-479) Extend User search in User lookup.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditPane/BulkEditListSidebar/LogsTab/LogsTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/LogsTab/LogsTab.js
@@ -29,8 +29,8 @@ import {
 } from '../../../../constants';
 import { useBulkOperationUsers } from '../../../../hooks/api/useBulkOperationUsers';
 import { getFullName } from '../../../../utils/getFullName';
-import { useLocationFilters } from '../../../../hooks';
-import { useSearchParams } from '../../../../hooks/useSearchParams';
+import { useLocationFilters, useSearchParams } from '../../../../hooks';
+import { customFilter } from '../../../../utils/helpers';
 
 export const LogsTab = () => {
   const intl = useIntl();
@@ -183,6 +183,7 @@ export const LogsTab = () => {
             dataOptions={userOptions}
             value={activeFilters[LOGS_FILTERS.USER]?.toString()}
             onChange={values => adaptedApplyFilters({ name: LOGS_FILTERS.USER, values })}
+            onFilter={customFilter}
           />
         </Accordion>
       </AccordionSet>

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -79,3 +79,7 @@ export const getVisibleColumnsKeys = (columns) => {
   return columns?.filter(item => item.selected).map(item => item.value);
 };
 
+export const customFilter = (value, dataOptions) => {
+  return dataOptions.filter(option => new RegExp(value, 'i').test(option.label));
+};
+


### PR DESCRIPTION
After this PR merget, Selection component will filter as `includes` instad of `starts with`

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/b995c921-76fc-44fb-96e9-db5ba7a3d091)
