### PR TITLE
UIBULKED-493 Rename "Find (full field search)" to "Find" for bulk edit Email in Users record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [UIBULKED-447](https://folio-org.atlassian.net/browse/UIBULKED-447) Bulk Edit Actions for Instance Notes - Find and Replace or Remove.
 * [UIBULKED-449](https://folio-org.atlassian.net/browse/UIBULKED-449) Navigate to FOLIO Instances Bulk Edit Screen.
 * [UIBULKED-456](https://folio-org.atlassian.net/browse/UIBULKED-456) Provide User-friendly Error Message for Optimistic Locking.
+* [UIBULKED-493](https://folio-org.atlassian.net/browse/UIBULKED-493) Rename "Find (full field search)" to "Find" for bulk edit Email in Users record type.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/constants/inAppActions.js
+++ b/src/constants/inAppActions.js
@@ -39,9 +39,15 @@ export const getPlaceholder = (formatMessage) => ({
   disabled: true,
 });
 
-export const getFindAction = (formatMessage) => ({
+export const getFindFullFieldAction = (formatMessage) => ({
   value: ACTIONS.FIND,
   label: formatMessage({ id: 'ui-bulk-edit.actions.findFullField' }),
+  disabled: false,
+});
+
+export const getFindAction = (formatMessage) => ({
+  value: ACTIONS.FIND,
+  label: formatMessage({ id: 'ui-bulk-edit.actions.find' }),
   disabled: false,
 });
 
@@ -132,7 +138,7 @@ export const noteActions = (formatMessage) => [
   getPlaceholder(formatMessage),
   getAddToExistingAction(formatMessage),
   getRemoveAllAction(formatMessage),
-  getFindAction(formatMessage),
+  getFindFullFieldAction(formatMessage),
   getChangeNoteTypeAction(formatMessage),
 ];
 
@@ -142,14 +148,14 @@ export const noteActionsWithMark = (formatMessage) => [
   getRemoveMarkAsStuffOnlyAction(formatMessage),
   getAddToExistingAction(formatMessage),
   getRemoveAllAction(formatMessage),
-  getFindAction(formatMessage),
+  getFindFullFieldAction(formatMessage),
   getChangeNoteTypeAction(formatMessage),
 ];
 
 export const electronicAccess = (formatMessage) => [
   getPlaceholder(formatMessage),
   getClearAction(formatMessage),
-  getFindAction(formatMessage),
+  getFindFullFieldAction(formatMessage),
   getReplaceAction(formatMessage),
 ];
 export const noteActionsWithDuplicate = (formatMessage) => [
@@ -158,7 +164,7 @@ export const noteActionsWithDuplicate = (formatMessage) => [
   getRemoveMarkAsStuffOnlyAction(formatMessage),
   getAddToExistingAction(formatMessage),
   getRemoveAllAction(formatMessage),
-  getFindAction(formatMessage),
+  getFindFullFieldAction(formatMessage),
   getChangeNoteTypeAction(formatMessage),
   getDuplicateToNoteAction(formatMessage),
 ];

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -329,6 +329,7 @@
   "options.placeholder": "Select option",
   "type.placeholder": "Select type",
   "actions.findFullField": "Find (full field search)",
+  "actions.find": "Find",
   "layer.column.options": "Options",
   "layer.column.actions": "Actions",
   "layer.column.data": "Data",


### PR DESCRIPTION
After this PR merged, "Find (full field search)" action will be changed to "Find" for Email type. Refs https://folio-org.atlassian.net/browse/UIBULKED-493

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/be2253a0-2907-4724-9c47-446e9c3ed7c7)

in the same time for all other places names weren't changed

![image](https://github.com/folio-org/ui-bulk-edit/assets/86330150/8445de36-0af7-44c6-9566-967674d9706e)
