### PR TITLE
UIBULKED-496: Sorting patron groups list on bulk edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [UIBULKED-450](https://folio-org.atlassian.net/browse/UIBULKED-450) Add button to navigate to MARC Instances Bulk Edit Screen.
 * [UIBULKED-490](https://folio-org.atlassian.net/browse/UIBULKED-490) Adding missing translations.
 * [UIBULKED-460](https://folio-org.atlassian.net/browse/UIBULKED-460) Add MARC Instances Bulk Edit Form.
+* [UIBULKED-496](https://folio-org.atlassian.net/browse/UIBULKED-496) Sorting patron groups list on bulk edit form.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ActionsRow.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ActionsRow.js
@@ -10,7 +10,7 @@ import { FINAL_ACTIONS } from '../../../../../constants';
 import { ACTION_VALUE_KEY } from './helpers';
 import { ValuesColumn } from './ValuesColumn';
 import { AdditionalActionParameters } from './AdditionalActionParameters';
-import { sortAlphabeticallyActions } from '../../../../../utils/sortAlphabetically';
+import { sortAlphabeticallyWithoutGroups } from '../../../../../utils/sortAlphabetically';
 import css from '../BulkEditInApp.css';
 
 export const ActionsRow = ({ option, actions, onChange }) => {
@@ -19,7 +19,7 @@ export const ActionsRow = ({ option, actions, onChange }) => {
   return actions.map((action, actionIndex) => {
     if (!action) return null;
 
-    const sortedActions = sortAlphabeticallyActions(action.actionsList, formatMessage({ id: 'ui-bulk-edit.actions.placeholder' }));
+    const sortedActions = sortAlphabeticallyWithoutGroups(action.actionsList, formatMessage({ id: 'ui-bulk-edit.actions.placeholder' }));
 
     return (
       <Fragment key={actionIndex}>

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ValuesColumn.js
@@ -29,6 +29,7 @@ import { useHoldingsNotes } from '../../../../../hooks/api/useHoldingsNotes';
 import { useElectronicAccessRelationships } from '../../../../../hooks/api/useElectronicAccess';
 import { useSearchParams } from '../../../../../hooks/useSearchParams';
 import { useInstanceNotes } from '../../../../../hooks/api/useInstanceNotes';
+import { sortAlphabeticallyWithoutGroups } from '../../../../../utils/sortAlphabetically';
 
 export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option }) => {
   const { formatMessage } = useIntl();
@@ -105,7 +106,7 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
   );
 
   const renderPatronGroupSelect = () => {
-    const patronGroups = Object.values(userGroups).reduce(
+    const patronGroups = sortAlphabeticallyWithoutGroups(Object.values(userGroups).reduce(
       (acc, { id, group, desc }) => {
         const description = desc ? `(${desc})` : '';
         const groupObject = {
@@ -123,7 +124,7 @@ export const ValuesColumn = ({ action, allActions, actionIndex, onChange, option
           label: formatMessage({ id: 'ui-bulk-edit.layer.selectPatronGroup' }),
         },
       ],
-    );
+    ), formatMessage({ id: 'ui-bulk-edit.layer.selectPatronGroup' }));
 
     return controlType === CONTROL_TYPES.PATRON_GROUP_SELECT && (
       <Select

--- a/src/utils/sortAlphabetically.js
+++ b/src/utils/sortAlphabetically.js
@@ -27,7 +27,7 @@ export const sortAlphabetically = (array, placeholder) => array?.sort((a, b) => 
   return categoryComparison;
 });
 
-export const sortAlphabeticallyActions = (array, placeholder) => {
+export const sortAlphabeticallyWithoutGroups = (array, placeholder) => {
   const collator = new Intl.Collator();
 
   return array?.sort((a, b) => {

--- a/src/utils/sortAlphabetically.test.js
+++ b/src/utils/sortAlphabetically.test.js
@@ -1,4 +1,4 @@
-import { sortAlphabetically, sortAlphabeticallyActions } from './sortAlphabetically';
+import { sortAlphabetically, sortAlphabeticallyWithoutGroups } from './sortAlphabetically';
 
 describe('sortAlphabetically', () => {
   it('should sort the array alphabetically', () => {
@@ -50,7 +50,7 @@ describe('sortAlphabeticallyActions', () => {
       { label: 'Placeholder' },
     ];
 
-    const sortedArray = sortAlphabeticallyActions(array, 'Placeholder');
+    const sortedArray = sortAlphabeticallyWithoutGroups(array, 'Placeholder');
 
     // Your expected sorted array based on the logic in the function
     const expectedSortedArray = [


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-496
Here we add alphabetical ordering for `patron groups` in bulk edit in the app form

https://github.com/folio-org/ui-bulk-edit/assets/72550466/f65d0a29-3327-451a-a2d5-2c38f6284b6e

