### PR TITLE
UIBULKED-468: Query - File with errors encountered during the record matching is downloaded in .txt format with wrong name from Logs tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [UIBULKED-498](https://folio-org.atlassian.net/browse/UIBULKED-498) Find (full subfield search) and Remove subfield in MARC Instance
 * [UIBULKED-461](https://folio-org.atlassian.net/browse/UIBULKED-461) Basic  UI only data entry validation on the MARC instance bulk edit form.
 * [UIBULKED-482](https://folio-org.atlassian.net/browse/UIBULKED-482) Find (full subfield search) and Append a new subfield for MARC Instance
+* [UIBULKED-468](https://folio-org.atlassian.net/browse/UIBULKED-468) Query - File with errors encountered during the record matching is downloaded in .txt format with wrong name from Logs tab
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/utils/getFileName.js
+++ b/src/utils/getFileName.js
@@ -7,7 +7,8 @@ export const getFileName = (item, triggeredFile) => {
       linkToMatchedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Matched-Records-Query-${item.id}.csv`,
       linkToModifiedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Updates-Preview-Query-${item.id}.csv`,
       linkToCommittedRecordsCsvFile: `${getFormattedFilePrefixDate()}-Changed-Records-Query-${item.id}.csv`,
-      linkToCommittedRecordsErrorsCsvFile: `${getFormattedFilePrefixDate()}-Committing-changes-Errors-Query-${item.id}.csv`
+      linkToCommittedRecordsErrorsCsvFile: `${getFormattedFilePrefixDate()}-Committing-changes-Errors-Query-${item.id}.csv`,
+      linkToMatchedRecordsErrorsCsvFile:`${getFormattedFilePrefixDate()}-Matching-Records-Errors-Query-${item.id}.csv`
     }[triggeredFile];
   }
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-468
Here we added a new mapping for file name building in `Logs` tab.