### PR TITLE
UIBULKED-440 Update custom filter to support groups 

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
@@ -253,6 +253,7 @@ export const ContentUpdatesForm = ({
                 dirty={!!field.option}
                 ariaLabel={`select-option-${index}`}
                 marginBottom0
+                listMaxHeight="50vh"
                 onFilter={customFilter}
               />
             </Col>

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
@@ -42,7 +42,7 @@ export const getFormattedDate = (value) => {
 };
 
 export const isAddButtonShown = (index, fields, options) => {
-  return index === fields.length - 1 && fields.length !== options.length - 1;
+  return index === fields.length - 1 && fields.length !== options.length;
 };
 
 export const getContentUpdatesBody = ({ bulkOperationId, contentUpdates, totalRecords }) => {

--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -50,6 +50,8 @@ export const getItemsWithPlaceholder = (items) => [
   ...items,
 ];
 
+export const getItemsWithoutPlaceholder = (items) => items.filter(item => item.value);
+
 export const identifierOptions = {
   [CAPABILITIES.USER]: [
     {
@@ -309,6 +311,11 @@ export const getInstanceNotes = (formatMessage, instanceNotes) => [
 
 export const getNotesOptions = (formatMessage, itemNotes) => [
   {
+    value: '',
+    label: formatMessage({ id: 'ui-bulk-edit.options.placeholder' }),
+    disabled: true,
+  },
+  {
     value: OPTIONS.ADMINISTRATIVE_NOTE,
     label: formatMessage({ id: 'ui-bulk-edit.layer.options.administrativeNote' }),
     disabled: false,
@@ -340,7 +347,7 @@ export const getDuplicateNoteOptions = (formatMessage) => [
 ];
 
 export const getItemsOptions = (formatMessage, itemNotes = []) => [
-  ...getNotesOptions(formatMessage, itemNotes),
+  ...getItemsWithoutPlaceholder(getNotesOptions(formatMessage, itemNotes)),
   {
     value: OPTIONS.STATUS,
     label: formatMessage({ id: 'ui-bulk-edit.layer.options.statusLabel' }),

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -86,7 +86,26 @@ export const getVisibleColumnsKeys = (columns) => {
 };
 
 export const customFilter = (value, dataOptions) => {
-  return dataOptions.filter(option => new RegExp(value, 'i').test(option.label));
+  return dataOptions.reduce((acc, option) => {
+    const optionLabelMatched = option.label.toLowerCase().includes(value.toLowerCase());
+
+    if (option.options?.length > 0) {
+      const filteredOptions = option.options.filter(opt => opt.label.toLowerCase().includes(value.toLowerCase()));
+
+      if (filteredOptions.length > 0) {
+        acc.push({
+          ...option,
+          options: filteredOptions,
+        });
+      } else if (optionLabelMatched) {
+        acc.push(option);
+      }
+    } else if (optionLabelMatched) {
+      acc.push(option);
+    }
+
+    return acc;
+  }, []);
 };
 
 export const setIn = (obj, path, value) => {

--- a/src/utils/helpers.test.js
+++ b/src/utils/helpers.test.js
@@ -1,0 +1,112 @@
+import { customFilter } from './helpers';
+
+describe('customFilter', () => {
+  const dataOptions = [
+    {
+      label: 'Category 1',
+      options: [
+        { label: 'Option 1-1' },
+        { label: 'Option 1-2' },
+      ],
+    },
+    {
+      label: 'Category 2',
+      options: [
+        { label: 'Option 2-1' },
+        { label: 'Option 2-2' },
+      ],
+    },
+    {
+      label: 'Category 3',
+      options: [],
+    },
+    {
+      label: 'Uncategorized Option',
+    },
+  ];
+
+  it('should return an empty array when no match is found', () => {
+    const value = 'NonExistent';
+    const result = customFilter(value, dataOptions);
+    expect(result).toEqual([]);
+  });
+
+  it('should filter options correctly when a match is found in nested options', () => {
+    const value = '1-1';
+    const expected = [
+      {
+        label: 'Category 1',
+        options: [
+          { label: 'Option 1-1' },
+        ],
+      },
+    ];
+    const result = customFilter(value, dataOptions);
+    expect(result).toEqual(expected);
+  });
+
+  it('should include the category if the category label matches the value', () => {
+    const value = 'Category 1';
+    const expected = [
+      {
+        label: 'Category 1',
+        options: [
+          { label: 'Option 1-1' },
+          { label: 'Option 1-2' },
+        ],
+      },
+    ];
+    const result = customFilter(value, dataOptions);
+    expect(result).toEqual(expected);
+  });
+
+  it('should include uncategorized options if the label matches the value', () => {
+    const value = 'Uncategorized';
+    const expected = [
+      {
+        label: 'Uncategorized Option',
+      },
+    ];
+    const result = customFilter(value, dataOptions);
+    expect(result).toEqual(expected);
+  });
+
+  it('should perform a case-insensitive match', () => {
+    const value = 'option 1-1';
+    const expected = [
+      {
+        label: 'Category 1',
+        options: [
+          { label: 'Option 1-1' },
+        ],
+      },
+    ];
+    const result = customFilter(value, dataOptions);
+    expect(result).toEqual(expected);
+  });
+
+  it('should return multiple matching categories and options', () => {
+    const value = 'Option';
+    const expected = [
+      {
+        label: 'Category 1',
+        options: [
+          { label: 'Option 1-1' },
+          { label: 'Option 1-2' },
+        ],
+      },
+      {
+        label: 'Category 2',
+        options: [
+          { label: 'Option 2-1' },
+          { label: 'Option 2-2' },
+        ],
+      },
+      {
+        label: 'Uncategorized Option',
+      },
+    ];
+    const result = customFilter(value, dataOptions);
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
After updating of Selection component, custom filter was updated to support filtering inside groups. Refs [UIBULKED-440](https://folio-org.atlassian.net/browse/UIBULKED-440)

Also in scope:
- update list height
- add missed placeholder in type select