### PR TITLE
UIBULKED-488: Bulk edit of user records in local mode (CSV approach) is not supported in Query search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [UIBULKED-487](https://folio-org.atlassian.net/browse/UIBULKED-487) Bulk edit of user records in local mode is not supported.
 * [UIBULKED-440](https://folio-org.atlassian.net/browse/UIBULKED-440) Add Search box to Group Component.
 * [UIBULKED-381](https://folio-org.atlassian.net/browse/UIBULKED-381) Localize Item record's column names
+* [UIBULKED-488](https://folio-org.atlassian.net/browse/UIBULKED-488) Bulk edit of user records in local mode (CSV approach) is not supported in Query search.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.js
@@ -10,6 +10,7 @@ import {
 import { CheckboxFilter } from '@folio/stripes/smart-components';
 import { Preloader } from '@folio/stripes-data-transfer-components';
 
+import { useStripes } from '@folio/stripes/core';
 import { ActionMenuGroup } from './ActionMenuGroup/ActionMenuGroup';
 import {
   APPROACHES,
@@ -37,6 +38,7 @@ const BulkEditActionMenu = ({
   onToggle,
   setFileInfo,
 }) => {
+  const stripes = useStripes();
   const intl = useIntl();
   const perms = useBulkPermissions();
   const {
@@ -69,6 +71,7 @@ const BulkEditActionMenu = ({
   const columns = visibleColumns || [];
   const visibleColumnKeys = getVisibleColumnsKeys(columns);
 
+  const isESC = stripes.user?.user?.consortium;
   const isStartBulkCsvActive = hasUserEditLocalPerm && currentRecordType === CAPABILITIES.USER;
   const isInitialStep = step === EDITING_STEPS.UPLOAD;
   const isStartBulkInAppActive =
@@ -76,7 +79,7 @@ const BulkEditActionMenu = ({
     && isInitialStep
     && [JOB_STATUSES.DATA_MODIFICATION, JOB_STATUSES.REVIEW_CHANGES].includes(bulkDetails?.status);
   const isStartMarkActive = isStartBulkInAppActive && currentRecordType === CAPABILITIES.INSTANCE;
-  const isStartManualButtonVisible = isStartBulkCsvActive && isInitialStep && countOfRecords > 0 && criteria !== CRITERIA.QUERY;
+  const isStartManualButtonVisible = isStartBulkCsvActive && isInitialStep && countOfRecords > 0 && criteria !== CRITERIA.QUERY && !isESC;
 
   const isLastUnselectedColumn = (value) => {
     return visibleColumnKeys?.length === 1 && visibleColumnKeys?.[0] === value;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-488

Here we add a condition to check if the user comes from an ESC environment to hide the action button for `local bulk-edit`