### PR TITLE
UIBULKED-489: "User" dropdown doesn't include Users that did bulk edit of ONLY Instance record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [UIBULKED-487](https://folio-org.atlassian.net/browse/UIBULKED-487) Bulk edit of user records in local mode is not supported.
 * [UIBULKED-440](https://folio-org.atlassian.net/browse/UIBULKED-440) Add Search box to Group Component.
 * [UIBULKED-381](https://folio-org.atlassian.net/browse/UIBULKED-381) Localize Item record's column names
+* [UIBULKED-489](https://folio-org.atlassian.net/browse/UIBULKED-489)"User" dropdown doesn't include Users that did bulk edit of ONLY Instance record type
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditPane/BulkEditListSidebar/LogsTab/LogsTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/LogsTab/LogsTab.js
@@ -60,7 +60,7 @@ export const LogsTab = () => {
 
   const adaptedApplyFilters = useCallback(({ name, values }) => applyFilters(name, values), [applyFilters]);
 
-  const { data } = useBulkOperationUsers();
+  const { data } = useBulkOperationUsers(activeFilters?.entityType);
 
   const userOptions = data?.users.map(({ id, firstName, lastName, middleName, preferredFirstName }) => ({
     label: getFullName({ firstName, lastName, middleName, preferredFirstName }),

--- a/src/constants/core.js
+++ b/src/constants/core.js
@@ -21,6 +21,13 @@ export const CAPABILITIES = {
   USER: 'USER',
 };
 
+export const QUERY_CAPABILITIES = {
+  HOLDINGS_RECORD: 'HOLDINGS_RECORD',
+  INSTANCE: 'INSTANCE',
+  ITEM: 'ITEM',
+  USER: 'USER',
+};
+
 export const RECORD_TYPES = {
   [CAPABILITIES.HOLDING]: 'Holdings',
   [CAPABILITIES.INSTANCE]: 'Instances',

--- a/src/hooks/api/useBulkOperationUsers.js
+++ b/src/hooks/api/useBulkOperationUsers.js
@@ -1,16 +1,29 @@
 import { useQuery } from 'react-query';
 import { useNamespace, useOkapiKy } from '@folio/stripes/core';
-import { CAPABILITIES } from '../../constants';
+import { QUERY_CAPABILITIES } from '../../constants';
 
 export const BULK_OPERATION_USERS_KEY = 'BULK_OPERATION_USERS_KEY';
 
-export const useBulkOperationUsers = (options) => {
+const buildQuery = (types) => {
+  if (types.length === 0) {
+    return `("${QUERY_CAPABILITIES.USER}" or "${QUERY_CAPABILITIES.ITEM}" or "${QUERY_CAPABILITIES.HOLDINGS_RECORD}" or "${QUERY_CAPABILITIES.INSTANCE}")`;
+  }
+  const includedCapabilities = types.map(type => `"${QUERY_CAPABILITIES[type]}"`).join(' or ');
+  return `(${includedCapabilities})`;
+};
+
+export const useBulkOperationUsers = (entityType = [], options) => {
   const ky = useOkapiKy();
   const [namespaceKey] = useNamespace({ key: BULK_OPERATION_USERS_KEY });
 
+  const queryFn = () => {
+    const query = buildQuery(entityType);
+    return ky.get(`bulk-operations/list-users?query=(entityType==${query})&offset=0`).json();
+  };
+
   const { data, isLoading } = useQuery({
-    queryKey: [namespaceKey],
-    queryFn: () => ky.get(`bulk-operations/list-users?query=(entityType==("${CAPABILITIES.USER}" or "${CAPABILITIES.ITEM}" or "${CAPABILITIES.HOLDING}"))&offset=0`).json(),
+    queryKey: [namespaceKey, entityType],
+    queryFn,
     ...options,
   });
 

--- a/src/hooks/api/useBulkOperationUsers.test.js
+++ b/src/hooks/api/useBulkOperationUsers.test.js
@@ -1,0 +1,60 @@
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+import { renderHook } from '@testing-library/react-hooks';
+import { waitFor, act } from '@testing-library/react';
+
+import { useBulkOperationUsers } from './useBulkOperationUsers';
+import { QUERY_CAPABILITIES } from '../../constants';
+
+jest.mock('@folio/stripes/core', () => ({
+  ...jest.requireActual('@folio/stripes/core'),
+  useOkapiKy: jest.fn(),
+  useNamespace: jest.fn().mockReturnValue(['1', '2', '3']),
+}));
+
+const queryClient = new QueryClient();
+
+// eslint-disable-next-line react/prop-types
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+const data = [
+  {
+    id: '1',
+    username: 'admin'
+  },
+  {
+    id: '2',
+    username: 'test_admin'
+  }
+];
+
+describe('useBulkOperationUsers', () => {
+  const mockGet = jest.fn(() => ({
+    json: () => Promise.resolve(data),
+  }));
+  beforeEach(() => {
+    queryClient.clear();
+    useOkapiKy.mockClear().mockReturnValue(
+      {
+        get: mockGet
+      }
+    );
+  });
+
+  it('should fetch related users', async () => {
+    const { result } = renderHook(() => useBulkOperationUsers([QUERY_CAPABILITIES.ITEM]), { wrapper });
+    await act(() => !result.current.isLoading);
+
+    await waitFor(() => expect(result.current.isLoading).toBeFalsy());
+
+    expect(result.current.data).toEqual(data);
+  });
+});


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-489

Here we changed logic of getting related users based on selected record types