### PR TITLE
UIBULKED-517 Disable buttons when preview is not ready yet

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInAppPreviewModal/BulkEditPreviewModal.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInAppPreviewModal/BulkEditPreviewModal.js
@@ -74,8 +74,8 @@ export const BulkEditPreviewModal = ({
         <BulkEditPreviewModalFooter
           downloadLabel={downloadLabel}
           bulkOperationId={bulkDetails?.id}
-          isCommitBtnDisabled={!hasLinkForDownload}
-          isDownloadBtnDisabled={!hasLinkForDownload}
+          isCommitBtnDisabled={!hasLinkForDownload || isPreviewLoading}
+          isDownloadBtnDisabled={!hasLinkForDownload || isPreviewLoading}
           onSave={handleBulkOperationStart}
           onDownload={onDownload}
           onKeepEditing={onKeepEditing}


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/573 was missed disabling buttons based on previe loading. Fixed in this PR.