### PR TITLE
UIBULKED-515: Limit identifiers options for holdings and items in ECS environment on Central tenant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [UIBULKED-499](https://folio-org.atlassian.net/browse/UIBULKED-499) Downloading .mrc file from Are you sure? form
 * [UIBULKED-527](https://folio-org.atlassian.net/browse/UIBULKED-527) include queryId to bulk-edit query request
 * [UIBULKED-518](https://folio-org.atlassian.net/browse/UIBULKED-518) The size of the dropdowns in the 'Actions' column is not consistent.
+* [UIBULKED-515](https://folio-org.atlassian.net/browse/UIBULKED-515) Limit identifiers options for holdings and items in ECS environment on Central tenant.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/shared/ListSelect/ListSelect.js
+++ b/src/components/shared/ListSelect/ListSelect.js
@@ -19,7 +19,7 @@ export const ListSelect = memo(({
   const isCentral = stripes.user?.user?.consortium?.centralTenantId;
 
   const options = identifierOptions[capabilities]?.filter((el) => {
-    return !(isCentral && el.isCentralTenant);
+    return !(isCentral && el.isIgnoredInCentralTenant);
   }).map((el) => ({
     value: el.value,
     label: intl.formatMessage({ id: el.label }),

--- a/src/components/shared/ListSelect/ListSelect.js
+++ b/src/components/shared/ListSelect/ListSelect.js
@@ -4,6 +4,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Select } from '@folio/stripes/components';
 
+import { useStripes } from '@folio/stripes/core';
 import { identifierOptions } from '../../../constants';
 
 
@@ -14,8 +15,12 @@ export const ListSelect = memo(({
   onChange
 }) => {
   const intl = useIntl();
+  const stripes = useStripes();
+  const isCentral = stripes.user?.user?.consortium?.centralTenantId;
 
-  const options = identifierOptions[capabilities]?.map((el) => ({
+  const options = identifierOptions[capabilities]?.filter((el) => {
+    return !(isCentral && el.isCentralTenant);
+  }).map((el) => ({
     value: el.value,
     label: intl.formatMessage({ id: el.label }),
     disabled: el.disabled,

--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -95,17 +95,17 @@ export const identifierOptions = {
     {
       value: IDENTIFIERS.FORMER_IDS,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.item.former',
-      isCentralTenant: true,
+      isIgnoredInCentralTenant: true,
     },
     {
       value: IDENTIFIERS.ACCESSION_NUMBER,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.item.accession',
-      isCentralTenant: true,
+      isIgnoredInCentralTenant: true,
     },
     {
       value: IDENTIFIERS.HOLDINGS_RECORD_ID,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.item.holdingsUUID',
-      isCentralTenant: true,
+      isIgnoredInCentralTenant: true,
     },
   ],
   [CAPABILITIES.HOLDING]: [
@@ -128,7 +128,7 @@ export const identifierOptions = {
     {
       value: IDENTIFIERS.ITEM_BARCODE,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.holdings.itemBarcodes',
-      isCentralTenant: true,
+      isIgnoredInCentralTenant: true,
     },
   ],
   [CAPABILITIES.INSTANCE]: [

--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -95,14 +95,17 @@ export const identifierOptions = {
     {
       value: IDENTIFIERS.FORMER_IDS,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.item.former',
+      isCentralTenant: true,
     },
     {
       value: IDENTIFIERS.ACCESSION_NUMBER,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.item.accession',
+      isCentralTenant: true,
     },
     {
       value: IDENTIFIERS.HOLDINGS_RECORD_ID,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.item.holdingsUUID',
+      isCentralTenant: true,
     },
   ],
   [CAPABILITIES.HOLDING]: [
@@ -125,6 +128,7 @@ export const identifierOptions = {
     {
       value: IDENTIFIERS.ITEM_BARCODE,
       label: 'ui-bulk-edit.list.filters.recordIdentifier.holdings.itemBarcodes',
+      isCentralTenant: true,
     },
   ],
   [CAPABILITIES.INSTANCE]: [


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-515

Here we added logic of hiding some options on `ESC` environment for` central tenant `.