### PR TITLE
UIBULKED-522 The progress bar disappears after clicking the 'Reset all' button on the 'Logs' tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [UIBULKED-499](https://folio-org.atlassian.net/browse/UIBULKED-499) Downloading .mrc file from Are you sure? form
 * [UIBULKED-527](https://folio-org.atlassian.net/browse/UIBULKED-527) include queryId to bulk-edit query request
 * [UIBULKED-518](https://folio-org.atlassian.net/browse/UIBULKED-518) The size of the dropdowns in the 'Actions' column is not consistent.
+* [UIBULKED-522](https://folio-org.atlassian.net/browse/UIBULKED-522) The progress bar disappears after clicking the 'Reset all' button on the 'Logs' tab.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/src/components/BulkEditPane/BulkEditListSidebar/LogsTab/LogsTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/LogsTab/LogsTab.js
@@ -40,7 +40,8 @@ export const LogsTab = () => {
     initialFileName,
     identifier,
     capabilities,
-    queryRecordType
+    queryRecordType,
+    progress,
   } = useSearchParams();
 
   const [
@@ -55,6 +56,7 @@ export const LogsTab = () => {
       queryRecordType,
       criteria: CRITERIA.LOGS,
       fileName: initialFileName,
+      progress,
     }
   });
 


### PR DESCRIPTION
After this PR merged, then after clicking on Reset all button - 'progress' search param will not be deleted from URI. Refs [UIBULKED-522](https://folio-org.atlassian.net/browse/UIBULKED-522)