### PR TITLE
[UIBULKED-536] Support new entity-types response format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [UIBULKED-522](https://folio-org.atlassian.net/browse/UIBULKED-522) The progress bar disappears after clicking the 'Reset all' button on the 'Logs' tab.
 * [UIBULKED-515](https://folio-org.atlassian.net/browse/UIBULKED-515) Limit identifiers options for holdings and items in ECS environment on Central tenant.
 * [UIBULKED-528](https://folio-org.atlassian.net/browse/UIBULKED-528) Add more sortings options to bulk edit logs.
+* [UIBULKED-536](https://folio-org.atlassian.net/browse/UIBULKED-536) Declare dependency on FQM `entity-types` interface; support new response format.
 
 ## [4.1.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.0) (2024-03-19)
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "home": "/bulk-edit",
     "okapiInterfaces": {
       "bulk-operations": "1.0",
+      "entity-types": "2.0",
       "users": "15.4 16.0"
     },
     "optionalOkapiInterfaces": {},

--- a/src/hooks/api/useRecordTypes.js
+++ b/src/hooks/api/useRecordTypes.js
@@ -12,7 +12,7 @@ export const useRecordTypes = ({ enabled } = {}) => {
     queryFn: async () => {
       const response = await ky.get('entity-types');
 
-      return response.json();
+      return (await response.json()).entityTypes;
     },
     cacheTime: Infinity,
     staleTime: Infinity,


### PR DESCRIPTION
The response of `mod-fqm-manager`’s `/entity-types` is changed such that it now includes an additional property for the current FQL version. As such, `ui-bulk-edit` needs to be updated to handle more than just the previous simple array.

Additionally, we are adding a dependency on the current `entity-types` interface version, as it seems to have been omitted.

# ⚠️  MUST BE MERGED AFTER https://github.com/folio-org/mod-fqm-manager/pull/403