### PR TITLE
UIBULKED-526: Localize S3 error messages

### DIFF
--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -95,7 +95,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -113,7 +113,7 @@ jobs:
           comment_title: BigTest Unit Test Statistics
 
       - name: Publish BigTest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bigtest-coverage-report
@@ -121,7 +121,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/src/components/BulkEditPane/BulkEditListSidebar/IdentifierTab/IdentifierTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/IdentifierTab/IdentifierTab.js
@@ -20,8 +20,7 @@ import {
   JOB_STATUSES,
   TRANSLATION_SUFFIX
 } from '../../../../constants';
-import { useBulkPermissions, useLocationFilters } from '../../../../hooks';
-import { useSearchParams } from '../../../../hooks/useSearchParams';
+import { useBulkPermissions, useLocationFilters, useSearchParams } from '../../../../hooks';
 import { useBulkOperationStart, useUpload } from '../../../../hooks/api';
 import { getIsDisabledByPerm } from '../utils/getIsDisabledByPerm';
 import { RootContext } from '../../../../context/RootContext';
@@ -160,11 +159,6 @@ export const IdentifierTab = () => {
       if (message === ERRORS.TOKEN) {
         showCallout({
           message: <FormattedMessage id="ui-bulk-edit.error.incorrectFormatted" values={{ fileName:fileToUpload.name }} />,
-          type: 'error',
-        });
-      } else {
-        showCallout({
-          message: <FormattedMessage id="ui-bulk-edit.error.uploadedFile" />,
           type: 'error',
         });
       }

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -539,5 +539,5 @@
   "error.mod-bulk-operations.not.upload.file.s3.invalid.configuration": "There is a problem with S3 configuration that prevents Bulk edit module to save files.  Please contact your hosting provider to check if the Bulk edit app has been configured correctly.",
   "error.mod-bulk-operations.not.download.file.from.s3": "There is a problem to retrieve data from S3.   Please contact your hosting provider to check S3 configuration.  Further details are available in Bulk edit app logs (mod-bulk-operations and mod-data-export-worker modules).",
   "error.mod-bulk-operations.not.confirm.changes.s3.issue": "There is a problem to retrieve data from S3.   Please contact your hosting provider to check S3 configuration.  Further details are available in Bulk edit app logs (mod-bulk-operations and mod-data-export-worker modules).",
-  "File uploading failed, reason: Cannot upload a file. Reason: file is empty.": "File uploading failed, reason: Cannot upload a file. Reason: file is empty."
+  "File uploading failed, reason: Cannot upload a file. Reason: file is empty.": "The uploaded file is empty."
 }

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -537,6 +537,6 @@
 
   "error.mod-bulk-operations.not.upload.file.s3.invalid.configuration": "There is a problem with S3 configuration that prevents Bulk edit module to save files.  Please contact your hosting provider to check if the Bulk edit app has been configured correctly.",
   "error.mod-bulk-operations.not.download.file.from.s3": "There is a problem to retrieve data from S3.   Please contact your hosting provider to check S3 configuration.  Further details are available in Bulk edit app logs (mod-bulk-operations and mod-data-export-worker modules).",
-  "error.mod-bulk-operations.not.confirm.changes.s3.issue": "There is a problem to retrieve data from S3.   Please contact your hosting provider to check S3 configuration.  Further details are available in Bulk edit app logs (mod-bulk-operations and mod-data-export-worker modules)."
-
+  "error.mod-bulk-operations.not.confirm.changes.s3.issue": "There is a problem to retrieve data from S3.   Please contact your hosting provider to check S3 configuration.  Further details are available in Bulk edit app logs (mod-bulk-operations and mod-data-export-worker modules).",
+  "File uploading failed, reason: Cannot upload a file. Reason: file is empty.": "File uploading failed, reason: Cannot upload a file. Reason: file is empty."
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-526
Fix for existing implementation. Here we removed the default error since it is handled in the `useErrorMessage` hook. Also, we updated the translation to correct errors when the uploaded file is empty.