### PR TITLE
UIBULKED-524: Localize Item's and Holdings' Notes names in ECS

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/BulkEditInApp.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/BulkEditInApp.test.js
@@ -156,7 +156,7 @@ describe('BulkEditInApp', () => {
     userEvent.click(permanentLocation);
     userEvent.click(selectionBtn);
 
-    expect(permanentLocation).toHaveAttribute('aria-selected', 'true');
+    expect(permanentLocation).toHaveAttribute('aria-selected', 'false');
   });
 
   it('should display correct status options in action select', async () => {
@@ -301,7 +301,7 @@ describe('BulkEditInApp', () => {
 
     userEvent.click(selectionBtn);
 
-    expect(optionStatus).toHaveAttribute('aria-selected', 'true');
+    expect(optionStatus).toHaveAttribute('aria-selected', 'false');
   });
 
   it('should display holdings set to true is checked by default', async () => {
@@ -327,7 +327,7 @@ describe('BulkEditInApp', () => {
     await waitFor(() => {
       const checkbox = getByRole('checkbox');
 
-      expect(optionStatus).toHaveAttribute('aria-selected', 'true');
+      expect(optionStatus).toHaveAttribute('aria-selected', 'false');
       expect(checkbox).toBeChecked();
     });
   });
@@ -355,7 +355,7 @@ describe('BulkEditInApp', () => {
     await waitFor(() => {
       const checkbox = screen.getByRole('checkbox');
 
-      expect(optionStatus).toHaveAttribute('aria-selected', 'true');
+      expect(optionStatus).toHaveAttribute('aria-selected', 'false');
       expect(checkbox).not.toBeChecked();
     });
   });

--- a/src/hooks/api/useHoldingsNotesEsc.js
+++ b/src/hooks/api/useHoldingsNotesEsc.js
@@ -4,7 +4,7 @@ import { OPTIONS, PARAMETERS_KEYS } from '../../constants';
 const NOTE_ESC = {
   NAMESPACE: 'holdings-note-types-esc',
   CATEGORY: 'ui-bulk-edit.category.holdingsNotes',
-  URL: 'holdings-note-types',
+  URL: 'holdings-note-types?limit=2000',
   NOTE_KEY: 'holdingsNoteTypes'
 };
 

--- a/src/hooks/api/useItemNotesEsc.js
+++ b/src/hooks/api/useItemNotesEsc.js
@@ -4,7 +4,7 @@ import { OPTIONS, PARAMETERS_KEYS } from '../../constants';
 const NOTE_ESC = {
   NAMESPACE: 'item-note-types-esc',
   CATEGORY: 'ui-bulk-edit.category.itemNotes',
-  URL: 'item-note-types',
+  URL: 'item-note-types?limit=2000',
   NOTE_KEY: 'itemNoteTypes'
 };
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-524

Here small fix for existing implementation. We added `limit` for `notes` requests