### PR TITLE
UIBULKED-542: Remove "Actions" Header from Actions menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [UIBULKED-526](https://folio-org.atlassian.net/browse/UIBULKED-526) Localize S3 error messages.
 * [UIBULKED-535](https://folio-org.atlassian.net/browse/UIBULKED-535) Permissions for editing Instances with MARC source.
 * [UIBULKED-524](https://folio-org.atlassian.net/browse/UIBULKED-524) Localize Item's and Holdings' Notes names in ECS.
+* [UIBULKED-542](https://folio-org.atlassian.net/browse/UIBULKED-542) Remove "Actions" Header from Actions menu.
 
 ## [4.1.4](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.4) (2024-05-29)
 

--- a/src/components/BulkEditActionMenu/ActionMenuGroup/ActionMenuGroup.css
+++ b/src/components/BulkEditActionMenu/ActionMenuGroup/ActionMenuGroup.css
@@ -3,7 +3,8 @@
 }
 
 .ActionMenuGroup {
-    margin-bottom: 20px;
+    margin-bottom: 10px;
+    margin-top: 5px;
 }
 
 .ActionMenuGroupBody {

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.js
@@ -32,7 +32,6 @@ import { getVisibleColumnsKeys } from '../../utils/helpers';
 
 import css from './ActionMenuGroup/ActionMenuGroup.css';
 
-
 const BulkEditActionMenu = ({
   onEdit,
   onToggle,

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.js
@@ -215,11 +215,7 @@ const BulkEditActionMenu = ({
 
   return (
     <>
-      <ActionMenuGroup
-        title={<FormattedMessage id="ui-bulk-edit.menuGroup.actions" />}
-      >
-        {renderLinkButtons()}
-      </ActionMenuGroup>
+      {renderLinkButtons()}
       {renderStartBulkEditButtons()}
       <ActionMenuGroup title={<FormattedMessage id="ui-bulk-edit.menuGroup.showColumns" />}>
         {Boolean(columnsOptions.length) && renderColumnsFilter()}

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.test.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.test.js
@@ -72,7 +72,7 @@ const renderBulkEditActionMenu = ({ step, capability, providerState = defaultPro
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[`/bulk-edit/1/preview?${params}`]}>
         <RootContext.Provider value={providerState}>
-          <BulkEditActionMenu onEdit={onEdit} onToggle={onToggle} />
+          <BulkEditActionMenu onEdit={onEdit} onToggle={onToggle} setFileInfo={jest.fn()} />
         </RootContext.Provider>
       </MemoryRouter>,
     </QueryClientProvider>,
@@ -89,11 +89,11 @@ describe('BulkEditActionMenu', () => {
   it('should display actions group', async () => {
     renderBulkEditActionMenu({
       step: EDITING_STEPS.UPLOAD,
-      capability: CAPABILITIES.USER,
+      capability: CAPABILITIES.INSTANCE,
       providerState: { ...defaultProviderState, visibleColumns: [] },
     });
 
-    expect(screen.getByText('ui-bulk-edit.menuGroup.actions')).toBeVisible();
+    expect(screen.getByText(/menuGroup.startEdit/)).toBeVisible();
   });
 
   it('should display download matched records action when available', () => {

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -139,7 +139,7 @@
 
   "start.edit": "Start bulk edit",
   "start.edit.instance": "Instances and Administrative data",
-  "start.edit.mark": "Instances with source MARC(POC)",
+  "start.edit.mark": "Instances with source MARC (POC)",
   "start.edit.csv": "Start bulk edit (Local)",
   "start.delete": "Start bulk delete",
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-542

Here we removed `menu group` from the action menu