### PR TITLE
UIBULKED-539: Handle validation cases for “In.1“, “In.2“, "Subfield"  fields on Bulk edit MARC fields form

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMark/validation.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMark/validation.js
@@ -28,7 +28,13 @@ const subfieldSchema = {
         .test(
           'is-valid-additional-subfield',
           'ui-bulk-edit.layer.marc.error.subfield',
-          (value) => /^[a-zA-Z0-9]+$/.test(value)
+          (value, context) => {
+            const { key } = context.parent;
+            if (key === 'SUBFIELD') {
+              return /^[a-zA-Z0-9]+$/.test(value);
+            }
+            return true;
+          }
         ),
     })),
   })

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMark/validation.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMark/validation.test.js
@@ -71,7 +71,7 @@ describe('getMarkFormErrors', () => {
     expect(errors).toEqual({
       '[0].tag': 'ui-bulk-edit.layer.marc.error',
       '[0].subfield': 'ui-bulk-edit.layer.marc.error.subfield',
-      '[0].actions[0].data[0].value': 'ui-bulk-edit.layer.marc.error.subfield'
+      '[0].actions[0].data[0].value': '[0].actions[0].data[0].value is a required field'
     });
   });
 

--- a/src/components/BulkEditPane/BulkEditPane.css
+++ b/src/components/BulkEditPane/BulkEditPane.css
@@ -24,7 +24,13 @@
 }
 
 .column.fallback {
-    width: calc(max(5%, 120px) + 100px);
+    width: calc(max(7%, 120px) + 100px);
+}
+
+@media (min-width: 1600px) {
+    .column.fallback {
+        width: calc(max(7%, 124px) + 100px);
+    }
 }
 
 .headerCell.field,


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-539

Here is a small fix for the existing validation process for `additional subfield`