### PR TITLE
UIBULKED-555: Rearrange item statuses order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [UIBULKED-501](https://folio-org.atlassian.net/browse/UIBULKED-501) Downloading .mrc file from Confirmation form
 * [UIBULKED-539](https://folio-org.atlassian.net/browse/UIBULKED-539) Handle validation cases for “In.1“, “In.2“, "Subfield" fields on Bulk edit MARC fields form.
 * [UIBULKED-549](https://folio-org.atlassian.net/browse/UIBULKED-549) Add additional item status.
+* [UIBULKED-555](https://folio-org.atlassian.net/browse/UIBULKED-555)Rearrange item statuses order.
 
 ## [4.1.4](https://github.com/folio-org/ui-bulk-edit/tree/v4.1.4) (2024-05-29)
 

--- a/src/constants/selectOptions.js
+++ b/src/constants/selectOptions.js
@@ -404,13 +404,18 @@ export const getItemStatusOptions = (formatMessage) => [
     disabled: false,
   },
   {
+    value: 'Missing',
+    label: formatMessage({ id: 'ui-bulk-edit.layer.options.missing' }),
+    disabled: false,
+  },
+  {
     value: 'Withdrawn',
     label: formatMessage({ id: 'ui-bulk-edit.layer.options.withdrawn' }),
     disabled: false,
   },
   {
-    value: 'Missing',
-    label: formatMessage({ id: 'ui-bulk-edit.layer.options.missing' }),
+    value: 'IN_PROCESS',
+    label: formatMessage({ id: 'ui-bulk-edit.layer.options.inProcess' }),
     disabled: false,
   },
   {
@@ -443,11 +448,6 @@ export const getItemStatusOptions = (formatMessage) => [
     label: formatMessage({ id: 'ui-bulk-edit.layer.options.unknown' }),
     disabled: false,
   },
-  {
-    value: 'IN_PROCESS',
-    label: formatMessage({ id: 'ui-bulk-edit.layer.options.inProcess' }),
-    disabled: false,
-  }
 ];
 
 export const EDIT_CAPABILITIES_OPTIONS = [


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-555

Here we changed the order of item statuses in the dropdown menu in bulk edit form.