### PR TITLE
UIBULKED-497: "Are you sure" preview displays outdated values after User changed selection on bulk edit form and clicked "Confirm changes"

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
@@ -237,7 +237,7 @@ export const ContentUpdatesForm = ({
 
         return {
           option: mappedOption,
-          tenants: tenants?.filter(item => item != null),
+          tenants: tenants?.filter(Boolean),
           actions: [{
             type,
             initial,

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
@@ -237,7 +237,7 @@ export const ContentUpdatesForm = ({
 
         return {
           option: mappedOption,
-          tenants,
+          tenants: tenants?.filter(item => item != null),
           actions: [{
             type,
             initial,


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIBULKED-497

Here is the small fix of addicting `tenants` in the `option` object