### PR TITLE
UIBULKED-553 Prevent duplication of errors for bulk operation start (follow up)

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInAppPreviewModal/BulkEditPreviewModal.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInAppPreviewModal/BulkEditPreviewModal.js
@@ -45,7 +45,7 @@ export const BulkEditPreviewModal = ({
         id: bulkDetails?.id,
         approach: APPROACHES.IN_APP,
         step: EDITING_STEPS.COMMIT,
-      });
+      }).then(showErrorMessage);
 
       onChangesCommited();
 

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditManualUploadModal/BulkEditManualUploadModal.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditManualUploadModal/BulkEditManualUploadModal.js
@@ -25,6 +25,7 @@ import {
 import { useBulkOperationDelete } from '../../../../hooks/api/useBulkOperationDelete';
 import { ListFileUploader } from '../../../shared/ListFileUploader';
 import { useSearchParams } from '../../../../hooks/useSearchParams';
+import { useErrorMessages } from '../../../../hooks/useErrorMessages';
 
 const BulkEditManualUploadModal = ({
   operationId,
@@ -38,6 +39,7 @@ const BulkEditManualUploadModal = ({
   const callout = useShowCallout();
   const controller = useRef(null);
   const { identifier, criteria } = useSearchParams();
+  const { showErrorMessage } = useErrorMessages();
 
   const { fileUpload } = useUpload();
   const { bulkOperationStart } = useBulkOperationStart();
@@ -102,7 +104,7 @@ const BulkEditManualUploadModal = ({
         id: operationId,
         step: EDITING_STEPS.COMMIT,
         approach: APPROACHES.MANUAL,
-      });
+      }).then(showErrorMessage);
 
       setCountOfRecords(committedNumOfRecords);
 

--- a/src/components/BulkEditPane/BulkEditListSidebar/IdentifierTab/IdentifierTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/IdentifierTab/IdentifierTab.js
@@ -157,7 +157,7 @@ export const IdentifierTab = () => {
 
       setIsFileUploaded(true);
     } catch (error) {
-      showErrorMessage(error, { fileName: fileToUpload.name });
+      showErrorMessage({ errorMessage: error.message }, { fileName: fileToUpload.name });
     }
   };
 

--- a/src/hooks/api/useBulkOperationStart.js
+++ b/src/hooks/api/useBulkOperationStart.js
@@ -8,12 +8,10 @@ import {
   JOB_STATUSES,
   EDITING_STEPS,
 } from '../../constants';
-import { useErrorMessages } from '../useErrorMessages';
 
 export const useBulkOperationStart = (mutationOptions = {}) => {
   const params = useRef({});
   const ky = useOkapiKy();
-  const { showErrorMessage } = useErrorMessages();
 
   const { refetch: fetchBulkOperation } = useQuery({
     queryFn: async () => {
@@ -71,8 +69,6 @@ export const useBulkOperationStart = (mutationOptions = {}) => {
 
       return data;
     },
-    onSuccess: showErrorMessage,
-    onError: showErrorMessage,
     ...mutationOptions,
   });
 

--- a/src/hooks/useConfirmChanges.js
+++ b/src/hooks/useConfirmChanges.js
@@ -65,9 +65,7 @@ export const useConfirmChanges = ({
         approach: APPROACHES.IN_APP,
         step: EDITING_STEPS.EDIT,
       }))
-      .then((response) => {
-        showErrorMessage(response);
-      })
+      .then(showErrorMessage)
       .catch((error) => {
         showErrorMessage(error);
         closePreviewModal();


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/625 1 case was missed, when errors can be show from `useSuccess, useErrors` callbacks or from `catch` section. This PR adding required fixes.