### PR TITLE
[UIPQB-126] Use tenant timezone for building queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In progress
 * [UIBULKED-540](https://folio-org.atlassian.net/browse/UIBULKED-540) Update identifiers names for Item record.
+* [UIPQB-126](https://folio-org.atlassian.net/browse/UIPQB-126) Use tenant timezone for building queries (adds use of permission `configuration.entries.collection.get`).
 
 ## [4.2.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.2.0) (2024-10-31)
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
           "bulk-operations.collection.get",
           "bulk-operations.item.get",
           "usergroups.collection.get",
-          "data-export.job.item.download"
+          "data-export.job.item.download",
+          "configuration.entries.collection.get"
         ]
       },
       {


### PR DESCRIPTION
The real work is being done in https://github.com/folio-org/ui-plugin-query-builder/pull/180; this just adds the new permission required by the query builder.

We need access to `mod-configuration` to retrieve the tenant locale information, as this is not made available by Stripes (Stripes exposes either the tenant locale, or the user locale if one is set, but not both). `mod-fqm-manager` is not aware of user timezones, so queries will always be built with regard to tenant timezone.

## Must be merged before https://github.com/folio-org/ui-plugin-query-builder/pull/180