### PR TITLE
UIBULKED-582 Temporarily remove error handling from publish-coordinator related logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In progress
 * [UIBULKED-540](https://folio-org.atlassian.net/browse/UIBULKED-540) Update identifiers names for Item record.
 * [UIPQB-126](https://folio-org.atlassian.net/browse/UIPQB-126) Use tenant timezone for building queries (adds use of permission `configuration.entries.collection.get`).
+* [UIBULKED-582](https://folio-org.atlassian.net/browse/UIBULKED-582) Temporarily remove error handling from publish-coordinator related logic.
 
 ## [4.2.0](https://github.com/folio-org/ui-bulk-edit/tree/v4.2.0) (2024-10-31)
 

--- a/src/hooks/api/useEscCommon.js
+++ b/src/hooks/api/useEscCommon.js
@@ -1,14 +1,12 @@
 import { useNamespace } from '@folio/stripes/core';
 import { useQuery } from 'react-query';
 import { usePublishCoordinator } from '../usePublishCoordinator';
-import { useErrorMessages } from '../useErrorMessages';
 
 const DEFAULT_DATA = {};
 
 export const useEscCommon = (key, url, tenants, mapResponse, options = {}) => {
   const [namespace] = useNamespace({ key });
   const { initPublicationRequest } = usePublishCoordinator(namespace);
-  const { showErrorMessage } = useErrorMessages();
 
   const { data = DEFAULT_DATA, isFetching } = useQuery({
     queryKey: [namespace, tenants],
@@ -23,8 +21,6 @@ export const useEscCommon = (key, url, tenants, mapResponse, options = {}) => {
     keepPreviousData: true,
     cacheTime: Infinity,
     staleTime: Infinity,
-    onError: showErrorMessage,
-    onSuccess: showErrorMessage,
     ...options
   });
 

--- a/src/hooks/api/useLocationEsc.js
+++ b/src/hooks/api/useLocationEsc.js
@@ -1,14 +1,12 @@
 import { useNamespace } from '@folio/stripes/core';
 import { useQuery } from 'react-query';
 import { usePublishCoordinator } from '../usePublishCoordinator';
-import { useErrorMessages } from '../useErrorMessages';
 
 const DEFAULT_DATA = {};
 
 export const useLocationEsc = (tenants, options = {}) => {
   const [namespace] = useNamespace({ key: 'locationsEsc' });
   const { initPublicationRequest } = usePublishCoordinator(namespace);
-  const { showErrorMessage } = useErrorMessages();
 
   const { data = DEFAULT_DATA, isFetching } = useQuery({
     queryKey: [namespace, tenants],
@@ -21,8 +19,6 @@ export const useLocationEsc = (tenants, options = {}) => {
       return publicationResults;
     },
     keepPreviousData: true,
-    onError: showErrorMessage,
-    onSuccess: showErrorMessage,
     ...options
   });
 

--- a/src/hooks/api/useNoteEsc.js
+++ b/src/hooks/api/useNoteEsc.js
@@ -6,7 +6,6 @@ import { useNamespace } from '@folio/stripes/core';
 
 import { getMappedAndSortedNotes } from '../../utils/helpers';
 import { PUBLISH_COORDINATOR_STATUSES_METHODS, usePublishCoordinator } from '../usePublishCoordinator';
-import { useErrorMessages } from '../useErrorMessages';
 
 const DEFAULT_DATA = {};
 
@@ -14,7 +13,6 @@ export const useNotesEsc = ({ namespaceKey, tenants, type, categoryId, url, note
   const [namespace] = useNamespace({ key: namespaceKey });
   const { initPublicationRequest } = usePublishCoordinator(namespace);
   const { formatMessage } = useIntl();
-  const { showErrorMessage } = useErrorMessages();
 
   const { data = DEFAULT_DATA, isFetching } = useQuery({
     queryKey: [namespace, tenants, url, type],
@@ -29,8 +27,6 @@ export const useNotesEsc = ({ namespaceKey, tenants, type, categoryId, url, note
     keepPreviousData: true,
     cacheTime: Infinity,
     staleTime: Infinity,
-    onError: showErrorMessage,
-    onSuccess: showErrorMessage,
     ...options
   });
 


### PR DESCRIPTION
After this PR merged - error callouts will be removed from the publish-coordinator related calls. Sometimes we are facing floating additional requests which are failed without impacting of functionality.

Based on it we have to remove callouts to not confuse users. It's temporary solution for Ramsons release.  Refs  [UIBULKED-582](https://folio-org.atlassian.net/browse/UIBULKED-582)

This part will be refactored in next release in scope of [UIBULKED-580](https://folio-org.atlassian.net/browse/UIBULKED-580). 
