### PR TITLE
UIBULKED-543 Rename Find (entire subfield search) to Find

### DIFF
--- a/src/constants/marcActions.js
+++ b/src/constants/marcActions.js
@@ -18,9 +18,9 @@ export const getPlaceholder = () => ({
   disabled: true,
 });
 
-export const getFindEntireFieldAction = () => ({
+export const getFindAction = () => ({
   value: ACTIONS.FIND,
-  label: <FormattedMessage id="ui-bulk-edit.actions.findEntireField" />,
+  label: <FormattedMessage id="ui-bulk-edit.actions.find" />,
   disabled: false,
 });
 
@@ -69,6 +69,6 @@ export const getReplaceWithAction = () => ({
 export const marcActions = () => [
   getPlaceholder(),
   getAddAction(),
-  getFindEntireFieldAction(),
+  getFindAction(),
   getRemoveAllAction(),
 ];

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -359,7 +359,6 @@
   "options.placeholder": "Select option",
   "type.placeholder": "Select type",
   "actions.findFullField": "Find (full field search)",
-  "actions.findEntireField": "Find (entire subfield search)",
   "actions.find": "Find",
   "layer.column.options": "Options",
   "layer.column.actions": "Actions",


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/672 PR was renamed `Find (full field search)` to `FInd`, but it also required rename `Find (entire subfield search)` to `Find` what is covered by current PR. 