### PR TITLE
UIBULKED-586 Cover missed case for statistical code

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/ContentUpdatesForm.js
@@ -167,7 +167,7 @@ export const ContentUpdatesForm = ({ fields, setFields, options }) => {
 
     // Check if there are rules should be applied based on if action changed and option value
     const fieldsWithRules = hasActionChanged
-      ? getFieldsWithRules({ fields: mappedFields, option, value, rowIndex })
+      ? getFieldsWithRules({ fields: mappedFields, option, rowIndex })
       : mappedFields;
 
     setFields(fieldsWithRules);

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.test.js
@@ -1732,7 +1732,7 @@ describe('ContentUpdatesForm helpers', () => {
           {
             ...fields[1],
             options: [
-              { value: OPTIONS.STATISTICAL_CODE, hidden: false },
+              { value: OPTIONS.STATISTICAL_CODE, hidden: true },
               { value: OPTIONS.ADMINISTRATIVE_NOTE, hidden: true },
             ],
           },
@@ -1837,14 +1837,14 @@ describe('ContentUpdatesForm helpers', () => {
           {
             ...fields[0],
             options: [
-              { value: OPTIONS.STATISTICAL_CODE, hidden: true },
+              { value: OPTIONS.STATISTICAL_CODE, hidden: false },
               { value: OPTIONS.ADMINISTRATIVE_NOTE, hidden: true },
             ],
           },
           {
             ...fields[1],
             options: [
-              { value: OPTIONS.STATISTICAL_CODE, hidden: true },
+              { value: OPTIONS.STATISTICAL_CODE, hidden: false },
               { value: OPTIONS.ADMINISTRATIVE_NOTE, hidden: true },
             ],
           },


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/685 one more condition was missed. When we have 2 statistical code selected with only Add or Remove action selected we should also hide Statistical code options from other select menus.

Refs: [UIBULKED-586](https://folio-org.atlassian.net/browse/UIBULKED-586)

Note: Changelog was updated in inital story.