### PR TITLE
UIBULKED-586 Add tests for REMOVE_ALL scenario

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.js
@@ -480,9 +480,10 @@ export const getFieldsWithRules = ({ fields, option, rowIndex }) => {
   if (option !== OPTIONS.STATISTICAL_CODE) return fields;
 
   return fields.map((field, i) => {
+    const maxFieldsLength = fields[0].options.length + 1; // +1 for extra STATISTICAL_CODE
     const isCurrentRow = i === rowIndex;
     const firstEmptyOptionIndex = fields.findIndex(({ option: optionValue }) => !optionValue);
-    const isFirstEmpty = fields.length === 5 && i === firstEmptyOptionIndex; // 5 is the maximum number of fields
+    const isFirstEmpty = fields.length === maxFieldsLength && i === firstEmptyOptionIndex;
     const isStatisticalCode = field.option === OPTIONS.STATISTICAL_CODE;
     const removeActionIndex = getActionIndex(fields, ACTIONS.REMOVE_SOME);
     const addActionIndex = getActionIndex(fields, ACTIONS.ADD_TO_EXISTING);

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/ContentUpdatesForm/helpers.test.js
@@ -1799,6 +1799,53 @@ describe('ContentUpdatesForm helpers', () => {
         expect(result).toEqual(expected);
       });
 
+      it('should remove first empty row when REMOVE_ALL selected and max count of fields added', () => {
+        const fields = [
+          {
+            option: OPTIONS.STATISTICAL_CODE,
+            options: [
+              { value: OPTIONS.STATISTICAL_CODE, hidden: false },
+              { value: OPTIONS.ADMINISTRATIVE_NOTE, hidden: false },
+            ],
+            actionsDetails: { actions: [{ name: ACTIONS.REMOVE_ALL }] },
+            id: 1,
+          },
+          {
+            option: '',
+            options: [
+              { value: OPTIONS.STATISTICAL_CODE, hidden: true },
+              { value: OPTIONS.ADMINISTRATIVE_NOTE, hidden: false },
+            ],
+            actionsDetails: { actions: [{ name: '' }] },
+            id: 2,
+          },
+          {
+            option: '',
+            options: [
+              { value: OPTIONS.STATISTICAL_CODE, hidden: true },
+              { value: OPTIONS.ADMINISTRATIVE_NOTE, hidden: false },
+            ],
+            actionsDetails: { actions: [{ name: '' }] },
+            id: 3,
+          },
+        ];
+
+        const result = getFieldsWithRules({
+          fields,
+          option: OPTIONS.STATISTICAL_CODE,
+          value: ACTIONS.REMOVE_ALL,
+          rowIndex: 0,
+        });
+
+        // fields[1] - first empty row removed
+        const expected = [
+          fields[0],
+          fields[2]
+        ];
+
+        expect(result).toEqual(expected);
+      });
+
       it('should update the hidden property on each option when ADD_TO_EXISTING and REMOVE_SOME selected', () => {
         const fields = [
           {


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/690 was implemented 1 condition when we already have 5 fields added, selecting remove all for statistical code should remove first empty row.

This PR adding tests for this functionality + hardcoded number of fields was replaced with dynamic value.

Refs: [UIBULKED-586](https://folio-org.atlassian.net/browse/UIBULKED-586)

Note: Changelog was updated in inital story.