### PR TITLE
UIBULKED-670 Rename Electronic access columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [UIBULKED-649](https://folio-org.atlassian.net/browse/UIBULKED-649) Correct plurals on records matched and confirmation forms.
 * [UIBULKED-671](https://folio-org.atlassian.net/browse/UIBULKED-671) Reset count of records when changing record type or identifier.
 * [UIBULKED-645](https://folio-org.atlassian.net/browse/UIBULKED-645) Rendering Instance record Classification in UI.
+* [UIBULKED-670](https://folio-org.atlassian.net/browse/UIBULKED-670) Rename Electronic access columns.
 
 ## [5.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v5.0.0) (2025-03-12)
 

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -80,11 +80,11 @@
   "list.preview.title": "Preview of records matched",
   "list.preview.titleChanged": "Preview of records changed",
 
-  "list.preview.electronicAccess.relationship": "Relationship",
+  "list.preview.electronicAccess.relationship": "URL relationship",
   "list.preview.electronicAccess.uri": "URI",
   "list.preview.electronicAccess.linkText": "Link text",
   "list.preview.electronicAccess.materialsSpecified": "Materials specified",
-  "list.preview.electronicAccess.publicNote": "Public note",
+  "list.preview.electronicAccess.publicNote": "URL public note",
 
   "list.preview.subject.subjectHeadings": "Subject headings",
   "list.preview.subject.subjectSource": "Subject source",


### PR DESCRIPTION
After this PR merged, columns will be renamed for Electronic access to be consistent with other places like Inventory, csv files etc.

Refs [UIBULKED-670](https://folio-org.atlassian.net/browse/UIBULKED-670)


