### PR TITLE
UIBULKED-618 Fix permission name

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
         "visible": true
       },
       {
-        "permissionName": "ui-bulk-edit.settings.edit",
+        "permissionName": "ui-bulk-edit.settings.create",
         "displayName": "Settings (Bulk edit): Can view, add, update profiles",
         "subPermissions": [
           "ui-bulk-edit.settings.view"


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/727 permission was named as edit but it should be create