### PR TITLE
UIBULKED-681 Fix bulk-edit ITEMS form problems

### DIFF
--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/controlsConfig.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/controlsConfig.js
@@ -23,14 +23,10 @@ import {
 } from '../../../../constants';
 import { getActionParameters } from '../../../../constants/actionParameters';
 
-const twoEmpty = {
-  actions: [
-    { name: '', value: '' },
-    { name: '', value: '' },
-  ]
-};
-
-const secondOnly = {
+/**
+ * Defines default action entry template, used when the first action is not from "FINAL" actions.
+ */
+const initialState = {
   actions: [
     { name: '', value: '' },
   ]
@@ -82,7 +78,7 @@ const firstActionConfig = {
   [OPTIONS.TEMPORARY_HOLDINGS_LOCATION]: {
     actions: replaceClearActions(),
     controlType: CONTROL_TYPES.LOCATION,
-    initialState: secondOnly
+    initialState
   },
   [OPTIONS.PERMANENT_HOLDINGS_LOCATION]: {
     actions: permanentHoldingsLocation(),
@@ -97,23 +93,27 @@ const firstActionConfig = {
   [OPTIONS.TEMPORARY_LOCATION]: {
     actions: replaceClearActions(),
     controlType: CONTROL_TYPES.LOCATION,
-    initialState: twoEmpty,
+    initialState,
   },
   [OPTIONS.PERMANENT_LOCATION]: {
     actions: replaceClearActions(),
     controlType: CONTROL_TYPES.LOCATION,
-    initialState: twoEmpty,
+    initialState,
   },
 
   [OPTIONS.TEMPORARY_LOAN_TYPE]: {
     actions: replaceClearActions(),
     controlType: CONTROL_TYPES.LOAN_TYPE,
-    initialState: secondOnly,
+    initialState,
   },
   [OPTIONS.PERMANENT_LOAN_TYPE]: {
     actions: permanentLoanTypeActions(),
     controlType: CONTROL_TYPES.LOAN_TYPE,
-    initialState: secondOnly,
+    initialState: {
+      actions: [
+        { name: ACTIONS.REPLACE_WITH, value: '' },
+      ]
+    },
   },
 
   [OPTIONS.SUPPRESS_FROM_DISCOVERY]: {
@@ -146,7 +146,7 @@ const firstActionConfig = {
   [OPTIONS.STATISTICAL_CODE]: {
     actions: statisticalCodeActions(),
     controlType: CONTROL_TYPES.STATISTICAL_CODES_SELECT,
-    initialState: secondOnly,
+    initialState,
   },
   [OPTIONS.STATUS]: {
     actions: statusActions(),
@@ -167,7 +167,7 @@ const firstActionConfig = {
     controlType: action => (action === ACTIONS.CHANGE_TYPE
       ? CONTROL_TYPES.NOTE_SELECT
       : CONTROL_TYPES.TEXTAREA),
-    initialState: secondOnly,
+    initialState,
   },
 
   [OPTIONS.CHECK_IN_NOTE]: {
@@ -254,28 +254,28 @@ const firstActionConfig = {
   [OPTIONS.ELECTRONIC_ACCESS_URL_RELATIONSHIP]: {
     actions: electronicAccessWithFindFullField(),
     controlType: CONTROL_TYPES.ELECTRONIC_ACCESS_RELATIONSHIP_SELECT,
-    initialState: secondOnly,
+    initialState,
   },
 
   [OPTIONS.ELECTRONIC_ACCESS_LINK_TEXT]: {
     actions: electronicAccess(),
     controlType: CONTROL_TYPES.TEXTAREA,
-    initialState: secondOnly,
+    initialState,
   },
   [OPTIONS.ELECTRONIC_ACCESS_MATERIALS_SPECIFIED]: {
     actions: electronicAccess(),
     controlType: CONTROL_TYPES.TEXTAREA,
-    initialState: secondOnly,
+    initialState,
   },
   [OPTIONS.ELECTRONIC_ACCESS_URI]: {
     actions: electronicAccess(),
     controlType: CONTROL_TYPES.TEXTAREA,
-    initialState: secondOnly,
+    initialState,
   },
   [OPTIONS.ELECTRONIC_ACCESS_URL_PUBLIC_NOTE]: {
     actions: electronicAccess(),
     controlType: CONTROL_TYPES.TEXTAREA,
-    initialState: secondOnly,
+    initialState,
   },
 };
 

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/controlsConfig.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditInApp/controlsConfig.test.js
@@ -1,0 +1,128 @@
+import {
+  getDefaultActionLists,
+  getControlType,
+  getDefaultActionState,
+  getNextActionLists,
+  getNextControlType,
+  getNextActionState,
+} from './controlsConfig';
+import {
+  OPTIONS,
+  ACTIONS,
+  CONTROL_TYPES,
+  APPROACHES,
+  CAPABILITIES,
+  emailActionsFind,
+  emailActionsReplace,
+  commonAdditionalActions,
+  noteActions,
+  noteActionsMarc,
+} from '../../../../constants';
+
+
+describe('actionConfig utilities', () => {
+  describe('getDefaultActionLists', () => {
+    it('returns empty array for unknown option', () => {
+      expect(getDefaultActionLists('UNKNOWN_OPTION', 'ANY')).toEqual([]);
+    });
+
+    it('returns email find actions for EMAIL_ADDRESS', () => {
+      const list = getDefaultActionLists(OPTIONS.EMAIL_ADDRESS, CAPABILITIES.USER);
+      expect(list).toEqual(emailActionsFind());
+    });
+
+    it('returns noteActionsMarc for ADMINISTRATIVE_NOTE with MARC record type', () => {
+      const list = getDefaultActionLists(OPTIONS.ADMINISTRATIVE_NOTE, APPROACHES.MARC);
+      expect(list).toEqual(noteActionsMarc());
+    });
+
+    it('returns noteActions for ADMINISTRATIVE_NOTE with non-MARC record type', () => {
+      const list = getDefaultActionLists(OPTIONS.ADMINISTRATIVE_NOTE, CAPABILITIES.INSTANCE);
+      expect(list).toEqual(noteActions());
+    });
+  });
+
+  describe('getControlType', () => {
+    it('returns null for unknown option', () => {
+      expect(getControlType('UNKNOWN_OPTION', ACTIONS.FIND)).toBeNull();
+    });
+
+    it('returns INPUT for EMAIL_ADDRESS controlType', () => {
+      expect(getControlType(OPTIONS.EMAIL_ADDRESS, ACTIONS.FIND)).toBe(CONTROL_TYPES.INPUT);
+    });
+
+    it('returns NOTE_SELECT for ADMINISTRATIVE_NOTE CHANGE_TYPE action', () => {
+      expect(getControlType(OPTIONS.ADMINISTRATIVE_NOTE, ACTIONS.CHANGE_TYPE))
+        .toBe(CONTROL_TYPES.NOTE_SELECT);
+    });
+
+    it('returns TEXTAREA for ADMINISTRATIVE_NOTE other action', () => {
+      expect(getControlType(OPTIONS.ADMINISTRATIVE_NOTE, 'OTHER_ACTION'))
+        .toBe(CONTROL_TYPES.TEXTAREA);
+    });
+  });
+
+  describe('getDefaultActionState', () => {
+    it('returns empty array for unknown option', () => {
+      expect(getDefaultActionState('UNKNOWN_OPTION', CAPABILITIES.ITEM)).toEqual([]);
+    });
+
+    it('returns template state for EMAIL_ADDRESS', () => {
+      const state = getDefaultActionState(OPTIONS.EMAIL_ADDRESS, CAPABILITIES.USER);
+      expect(state).toHaveProperty('actions');
+      expect(state.actions).toEqual([
+        { name: ACTIONS.FIND, value: '' },
+        { name: ACTIONS.REPLACE_WITH, value: '' },
+      ]);
+    });
+
+    it('includes parameters for CHECK_IN_NOTE recordType', () => {
+      const state = getDefaultActionState(OPTIONS.CHECK_IN_NOTE, 'USER');
+      expect(state.actions[0]).toHaveProperty('parameters');
+    });
+  });
+
+  describe('getNextActionLists', () => {
+    it('returns empty for non-FIND action or unsupported option', () => {
+      expect(getNextActionLists(OPTIONS.EMAIL_ADDRESS, 'OTHER')).toEqual([]);
+      expect(getNextActionLists('UNKNOWN_OPTION', ACTIONS.FIND)).toEqual([]);
+    });
+
+    it('returns replace actions for EMAIL_ADDRESS on FIND', () => {
+      const next = getNextActionLists(OPTIONS.EMAIL_ADDRESS, ACTIONS.FIND);
+      expect(next).toEqual(emailActionsReplace());
+    });
+
+    it('returns common additional actions for ITEM_NOTE on FIND', () => {
+      const next = getNextActionLists(OPTIONS.ITEM_NOTE, ACTIONS.FIND);
+      expect(next).toEqual(commonAdditionalActions());
+    });
+  });
+
+  describe('getNextControlType', () => {
+    it('returns null if action is not FIND', () => {
+      expect(getNextControlType(OPTIONS.EMAIL_ADDRESS, 'OTHER')).toBeNull();
+    });
+
+    it('returns input for EMAIL_ADDRESS on FIND', () => {
+      expect(getNextControlType(OPTIONS.EMAIL_ADDRESS, ACTIONS.FIND))
+        .toBe(CONTROL_TYPES.INPUT);
+    });
+
+    it('returns null for unsupported option on FIND', () => {
+      expect(getNextControlType('UNKNOWN_OPTION', ACTIONS.FIND)).toBeNull();
+    });
+  });
+
+  describe('getNextActionState', () => {
+    it('returns empty array when not FIND or unsupported', () => {
+      expect(getNextActionState(OPTIONS.EMAIL_ADDRESS, 'OTHER')).toEqual([]);
+      expect(getNextActionState('UNKNOWN_OPTION', ACTIONS.FIND)).toEqual([]);
+    });
+
+    it('returns template next state for FIND on supported option', () => {
+      const nextState = getNextActionState(OPTIONS.EMAIL_ADDRESS, ACTIONS.FIND);
+      expect(nextState).toEqual([{ name: '', value: '' }]);
+    });
+  });
+});


### PR DESCRIPTION
This PR is a continuation of a series of stories on refactoring bulk edit forms. It's covering problems for ITEMS form which were found in dev verefication stage.

Please check previous PRs if you need more context: 

✅ [UIBULKED-679](https://folio-org.atlassian.net/browse/UIBULKED-679) PR: https://github.com/folio-org/ui-bulk-edit/pull/735 - MARC form was refactored here
✅ [UIBULKED-683](https://folio-org.atlassian.net/browse/UIBULKED-683) PR: https://github.com/folio-org/ui-bulk-edit/pull/740 - ITEMS, HOLDINGS, INSTANCES, USERS forms were refactored here
➡️ [UIBULKED-681](https://folio-org.atlassian.net/browse/UIBULKED-681) PR: current

Changes: 
- for Permanent loan type incorrect template for initial value was updated
- was realised that only one template is required now instead of two, so it was simplified
- tests for controlConfig were added

Permanent loan type preview: 

![ver](https://github.com/user-attachments/assets/8bd6f138-b70e-42d2-a6ff-d6f1b4bde5e5)
