### PR TITLE
UIBULKED-661 Hide 'Edit' action for locked profiled from unauthorized user

### DIFF
--- a/src/components/BulkEditProfiles/BulkEditProfileDetails.js
+++ b/src/components/BulkEditProfiles/BulkEditProfileDetails.js
@@ -70,7 +70,11 @@ export const BulkEditProfileDetails = ({
   const { id } = useParams();
   const history = useHistory();
   const accordionStatusRef = useRef();
-  const { hasSettingsCreatePerms, hasSettingsDeletePerms } = useBulkPermissions();
+  const {
+    hasSettingsCreatePerms,
+    hasSettingsDeletePerms,
+    hasSettingsLockPerms,
+  } = useBulkPermissions();
   const [isDeleteProfileModalOpen, toggleDeleteProfileModalModal] = useModalToggle();
 
   const {
@@ -93,28 +97,33 @@ export const BulkEditProfileDetails = ({
   }, [deleteProfile, id, toggleDeleteProfileModalModal]);
 
   const renderActionMenu = useCallback(({ onToggle }) => {
+    // Locked profile can't be deleted; user must have permission to delete profiles
     const isDeletionAllowed = hasSettingsDeletePerms && !profile?.locked;
+    // Locked profile can be edited if user has permission to lock profiles
+    const isEditAllowed = !profile?.locked || hasSettingsLockPerms;
 
     return hasSettingsCreatePerms && (
       <MenuSection id="bulk-edit-profile-action-menu">
-        <Button
-          aria-label={intl.formatMessage({ id: 'stripes-core.button.edit' })}
-          buttonStyle="dropdownItem"
-          onClick={() => {
-            onToggle();
-            history.push({
-              pathname: `${id}/edit`,
-              search: history.location.search,
-            });
-          }}
-        >
-          <Icon
-            size="small"
-            icon="edit"
+        {isEditAllowed && (
+          <Button
+            aria-label={intl.formatMessage({ id: 'stripes-core.button.edit' })}
+            buttonStyle="dropdownItem"
+            onClick={() => {
+              onToggle();
+              history.push({
+                pathname: `${id}/edit`,
+                search: history.location.search,
+              });
+            }}
           >
-            <FormattedMessage id="stripes-core.button.edit" />
-          </Icon>
-        </Button>
+            <Icon
+              size="small"
+              icon="edit"
+            >
+              <FormattedMessage id="stripes-core.button.edit" />
+            </Icon>
+          </Button>
+        )}
         {isDeletionAllowed && (
           <Button
             aria-label={intl.formatMessage({ id: 'stripes-core.button.delete' })}
@@ -138,6 +147,7 @@ export const BulkEditProfileDetails = ({
   }, [
     hasSettingsCreatePerms,
     hasSettingsDeletePerms,
+    hasSettingsLockPerms,
     history,
     id,
     intl,


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/UIBULKED-661

> Scenario 5: Viewing Locked Profile  - Unauthorized user
> Given I have the permission required viewing or updating profiles but not for locking and unlocking bulk edit profiles
When I view an existing profile from Settings → Bulk Edit → [Record Type]s bulk edit profiles or I create a new profile
Then I see Lock profile checkbox selected and the checkbox is read only AND Action menu does not contain option for editing or deleting profile. The profile can only be duplicated.