### PR TITLE
[UIPQB-237] Support improved organization handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [UIBULKED-658](https://folio-org.atlassian.net/browse/UIBULKED-658) Add "Update profile" form
 * [UIBULKED-674](https://folio-org.atlassian.net/browse/UIBULKED-674) View "Bulk edits" of existing bulk edit profile
 * [UIBULKED-661](https://folio-org.atlassian.net/browse/UIBULKED-661) Locking and unlocking a bulk edit profile
+* [UIPQB-237](https://folio-org.atlassian.net/browse/UIPQB-237) Handle organization API calls for the query builder
 
 ## [5.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v5.0.0) (2025-03-12)
 

--- a/src/components/BulkEditPane/BulkEditListSidebar/QueryTab/QueryTab.js
+++ b/src/components/BulkEditPane/BulkEditListSidebar/QueryTab/QueryTab.js
@@ -65,6 +65,7 @@ export const QueryTab = ({ onClearState }) => {
     queryDetailsDataSource,
     testQueryDataSource,
     getParamsSource,
+    getOrganizations,
     cancelQueryDataSource,
     runQueryDataSource
   } = useQueryPlugin(recordTypeId);
@@ -112,6 +113,7 @@ export const QueryTab = ({ onClearState }) => {
         entityTypeDataSource={entityTypeDataSource}
         testQueryDataSource={testQueryDataSource}
         getParamsSource={getParamsSource}
+        getOrganizations={getOrganizations}
         queryDetailsDataSource={queryDetailsDataSource}
         onQueryRunFail={() => {}}
         cancelQueryDataSource={cancelQueryDataSource}

--- a/src/hooks/api/useQueryPlugin.js
+++ b/src/hooks/api/useQueryPlugin.js
@@ -34,6 +34,16 @@ export const useQueryPlugin = (recordType) => {
     return response.json();
   };
 
+  const getOrganizations = async (ids, property) => ky
+    .get('organizations/organizations', {
+      searchParams: {
+        query: ids.map((id) => `id=="${id}"`).join(' or '),
+        limit: ids.length,
+      },
+    })
+    .json()
+    .then((response) => response.organizations.map((org) => ({ value: org.id, label: org[property] })));
+
   const cancelQueryDataSource = async ({ queryId }) => {
     return ky.delete(`query/${queryId}`);
   };
@@ -53,6 +63,7 @@ export const useQueryPlugin = (recordType) => {
     queryDetailsDataSource,
     testQueryDataSource,
     getParamsSource,
+    getOrganizations,
     cancelQueryDataSource,
     runQueryDataSource,
   };


### PR DESCRIPTION
# [Jira UIPQB-237](https://folio-org.atlassian.net/browse/UIPQB-237)

## Purpose
FQM's ability to provide column values is limited for organization names and code when the env has over 1000 organizations, as discovered [here](https://folio-org.atlassian.net/browse/UIPQB-204). To resolve this, we use the organization plugin to allow the user to search for organizations directly, however, several places where queries are displayed still relied on FQM's column values for organization names/codes, causing some names/codes to not load if outside the 1000 organization limit.

## Approach
Now, the QB will fetch organization names/codes intelligently, however, it needs to make new API calls for this action. As with all others in the QB, the embedding module must pass along a function to make these calls; this PR adds the requisite new `getOrganizations` prop for bulk edit.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

> [!NOTE]
> 
> This does add an API call to `mod-organizations` which is not backed by a corresponding `package.json` change to declare the API dependency. However, FQM itself requires that `mod-organizations` be present with the requisite interface version (and checks permissions), so this code would only be executed iff FQM is satisfied with `organizations` being installed. Is this sufficient, or should we add a dependency here, too?