### PR TITLE
UIBULKED-696 Fix call of hasPerm

### DIFF
--- a/src/components/BulkEditPane/BulkEditMarcLayer/BulkEditMarcLayer.js
+++ b/src/components/BulkEditPane/BulkEditMarcLayer/BulkEditMarcLayer.js
@@ -49,7 +49,7 @@ export const BulkEditMarcLayer = ({
 
   const filteredOptions = filterOptionsByPermissions(getAdministrativeDataOptions(formatMessage), stripes);
   const sortedOptions = sortAlphabetically(filteredOptions)
-    .filter(option => !option.perms || option.perms.some(stripes.hasPerm)); // Filter options based on permissions
+    .filter(option => !option.perms || option.perms.some(perm => stripes.hasPerm(perm))); // Filter options based on permissions
 
   const contentUpdates = getMappedContentUpdates(fields, sortedOptions);
 


### PR DESCRIPTION
In scope of https://github.com/folio-org/ui-bulk-edit/pull/770, there is a problem with call hasPerm. `this` is underfine when calling inside `.some()`