### PR TITLE
UIBULKED-685 Display electronic access for item records in the subtable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [UIBULKED-690](https://folio-org.atlassian.net/browse/UIBULKED-690) Setting instances as staff/discovery unsuppressed and as deleted in one bulk edit job
 * [UIBULKED-694](https://folio-org.atlassian.net/browse/UIBULKED-694) Populate "Status" column on the list of existing profiles
 * [UIBULKED-651](https://folio-org.atlassian.net/browse/UIBULKED-651) Creating and Updating Profile for Instances with Source MARC bulk edit
+* [UIBULKED-690](https://folio-org.atlassian.net/browse/UIBULKED-690) Display electronic access for item records in the subtable
 
 ## [5.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v5.0.0) (2025-03-12)
 

--- a/src/utils/mappers.js
+++ b/src/utils/mappers.js
@@ -46,7 +46,7 @@ const formatData = ({ capability, column, data }) => {
       return <FormattedUTCDate value={data} />;
     case dataType === DATA_TYPES.DATE_TIME:
       return <FolioFormattedTime dateString={data} />;
-    case [CAPABILITIES.HOLDING, CAPABILITIES.INSTANCE].includes(capability) && field === CUSTOM_ENTITY_COLUMNS.ELECTRONIC_ACCESS:
+    case [CAPABILITIES.HOLDING, CAPABILITIES.INSTANCE, CAPABILITIES.ITEM].includes(capability) && field === CUSTOM_ENTITY_COLUMNS.ELECTRONIC_ACCESS:
       return <EmbeddedTable value={data} headTitles={ELECTRONIC_ACCESS_HEAD_TITLES} />;
     case [CAPABILITIES.INSTANCE].includes(capability) && field === CUSTOM_ENTITY_COLUMNS.SUBJECT:
       return <EmbeddedTable value={data} headTitles={SUBJECT_HEAD_TITLES} />;


### PR DESCRIPTION
Display electronic access for items in table format was added here. Previously it was implemented also for holdings and instances.

<img width="1767" height="807" alt="image" src="https://github.com/user-attachments/assets/5fb853d3-5275-41a3-b5da-8c82d52795c1" />

Refs: [UIBULKED-685](https://folio-org.atlassian.net/browse/UIBULKED-685)