### PR TITLE
UIBULKED-758 Fix issues with displaying note type containing text in brackets on bulk edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [UIBULKED-722](https://folio-org.atlassian.net/browse/UIBULKED-722) Include universal read-only permissions
 * [UIBULKED-753](https://folio-org.atlassian.net/browse/UIBULKED-753) Dependency correction: omit `@testing-library/react-hooks` since it is not used
 * [UIBULKED-757](https://folio-org.atlassian.net/browse/UIBULKED-757) Behavior of "Reset all" button is not independent on Identifier, Query tabs
+* [UIBULKED-758](https://folio-org.atlassian.net/browse/UIBULKED-758) Fix issues with displaying note type containing text in brackets on bulk edit form
 
 ## [5.0.0](https://github.com/folio-org/ui-bulk-edit/tree/v5.0.0) (2025-03-12)
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -124,6 +124,12 @@ export const updateIn = (obj, path, updater) => {
   return update(copy, path, updater);
 };
 
+const stripTenantSuffix = (label, tenant) => {
+  if (!label || !tenant) return label;
+  const suffix = ` (${tenant})`;
+  return label.endsWith(suffix) ? label.slice(0, -suffix.length) : label;
+};
+
 export const removeDuplicatesByValue = (arr = [], tenants = []) => {
   const valueMap = new Map();
 
@@ -133,12 +139,7 @@ export const removeDuplicatesByValue = (arr = [], tenants = []) => {
     } else {
       const existingItem = valueMap.get(item.value);
 
-      const startIndex = existingItem.label.indexOf('(');
-      const endIndex = existingItem.label.indexOf(')', startIndex);
-
-      if (startIndex !== -1 && endIndex !== -1) {
-        existingItem.label = existingItem.label.slice(0, startIndex).trim() + existingItem.label.slice(endIndex + 1).trim();
-      }
+      existingItem.label = stripTenantSuffix(existingItem.label, existingItem.tenant[0]);
 
       if (!existingItem.tenant.includes(item.tenant)) {
         existingItem.tenant.push(item.tenant);
@@ -149,12 +150,7 @@ export const removeDuplicatesByValue = (arr = [], tenants = []) => {
   if (tenants.length === 1) {
     arr.forEach(item => {
       const existingItem = valueMap.get(item.value);
-      const tenantStartIndex = existingItem.label.indexOf('(');
-      const tenantEndIndex = existingItem.label.indexOf(')', tenantStartIndex);
-
-      if (tenantStartIndex !== -1 && tenantEndIndex !== -1) {
-        existingItem.label = existingItem.label.slice(0, tenantStartIndex).trim() + existingItem.label.slice(tenantEndIndex + 1).trim();
-      }
+      existingItem.label = stripTenantSuffix(existingItem.label, item.tenant);
     });
   }
 

--- a/src/utils/helpers.test.js
+++ b/src/utils/helpers.test.js
@@ -120,23 +120,23 @@ describe('customFilter', () => {
 });
 
 describe('removeDuplicatesByValue', () => {
-  it('should remove duplicates by the value field, merge tenant arrays, and remove parentheses from labels', () => {
+  it('should remove duplicates by the value field, merge tenant arrays, and strip tenant suffix from labels', () => {
     const input = [
-      { value: 'college', label: 'College (Main)', tenant: 'Tenant 1' },
-      { value: 'college', label: 'College (Main)', tenant: 'Tenant 2' },
-      { value: 'university', label: 'University', tenant: 'Tenant 3' },
+      { value: 'college', label: 'College (Tenant 1)', tenant: 'Tenant 1' },
+      { value: 'college', label: 'College (Tenant 2)', tenant: 'Tenant 2' },
+      { value: 'university', label: 'University (Tenant 3)', tenant: 'Tenant 3' },
     ];
 
     const expectedOutput = [
       { value: 'college', label: 'College', tenant: ['Tenant 1', 'Tenant 2'] },
-      { value: 'university', label: 'University', tenant: ['Tenant 3'] },
+      { value: 'university', label: 'University (Tenant 3)', tenant: ['Tenant 3'] },
     ];
 
     const result = removeDuplicatesByValue(input, ['Tenant 1', 'Tenant 2', 'Tenant 3']);
     expect(result).toEqual(expectedOutput);
   });
 
-  it('should handle arrays with no duplicates and leave labels unchanged if there are no parentheses', () => {
+  it('should handle arrays with no duplicates and leave labels unchanged if there is no tenant suffix', () => {
     const input = [
       { value: 'college', label: 'College', tenant: 'Tenant 1' },
       { value: 'university', label: 'University', tenant: 'Tenant 2' },
@@ -151,15 +151,57 @@ describe('removeDuplicatesByValue', () => {
     expect(result).toEqual(expectedOutput);
   });
 
-  it('should remove parentheses from labels when tenants array has only one element', () => {
+  it('should strip tenant suffix from labels when tenants array has only one element', () => {
     const input = [
-      { value: 'college', label: 'College (Main)', tenant: 'Tenant 1' },
-      { value: 'university', label: 'University (Main)', tenant: 'Tenant 2' },
+      { value: 'college', label: 'College (Tenant 1)', tenant: 'Tenant 1' },
+      { value: 'university', label: 'University (Tenant 1)', tenant: 'Tenant 1' },
     ];
 
     const expectedOutput = [
       { value: 'college', label: 'College', tenant: ['Tenant 1'] },
-      { value: 'university', label: 'University', tenant: ['Tenant 2'] },
+      { value: 'university', label: 'University', tenant: ['Tenant 1'] },
+    ];
+
+    const result = removeDuplicatesByValue(input, ['Tenant 1']);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should preserve custom parentheses in labels that are not the tenant suffix', () => {
+    const input = [
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra) (Tenant 1)', tenant: 'Tenant 1' },
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra) (Tenant 2)', tenant: 'Tenant 2' },
+    ];
+
+    const expectedOutput = [
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra)', tenant: ['Tenant 1', 'Tenant 2'] },
+    ];
+
+    const result = removeDuplicatesByValue(input, ['Tenant 1', 'Tenant 2']);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should preserve custom parentheses when tenants array has only one element', () => {
+    const input = [
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra) (Tenant 1)', tenant: 'Tenant 1' },
+    ];
+
+    const expectedOutput = [
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra)', tenant: ['Tenant 1'] },
+    ];
+
+    const result = removeDuplicatesByValue(input, ['Tenant 1']);
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should leave labels untouched when items have no tenant (non-ECS data)', () => {
+    const input = [
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra)' },
+      { value: 'barcode', label: 'Barcode' },
+    ];
+
+    const expectedOutput = [
+      { value: 'barcode', label: 'Barcode', tenant: [undefined] },
+      { value: 'lastCheckIn', label: 'Last Check In Date (Sierra)', tenant: [undefined] },
     ];
 
     const result = removeDuplicatesByValue(input, ['Tenant 1']);
@@ -168,13 +210,13 @@ describe('removeDuplicatesByValue', () => {
 
   it('should return results sorted by label in alphabetical order', () => {
     const input = [
-      { value: 'university', label: 'University (Main)', tenant: 'Tenant 1' },
-      { value: 'college', label: 'College (Main)', tenant: 'Tenant 2' },
+      { value: 'university', label: 'University (Tenant 1)', tenant: 'Tenant 1' },
+      { value: 'college', label: 'College (Tenant 2)', tenant: 'Tenant 2' },
     ];
 
     const expectedOutput = [
-      { value: 'college', label: 'College (Main)', tenant: ['Tenant 2'] },
-      { value: 'university', label: 'University (Main)', tenant: ['Tenant 1'] },
+      { value: 'college', label: 'College (Tenant 2)', tenant: ['Tenant 2'] },
+      { value: 'university', label: 'University (Tenant 1)', tenant: ['Tenant 1'] },
     ];
 
     const result = removeDuplicatesByValue(input, ['Tenant 1', 'Tenant 2']);

--- a/src/utils/mappers.js
+++ b/src/utils/mappers.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { FormattedUTCDate } from '@folio/stripes/components';
+import { FormattedUTCDate, dayjs } from '@folio/stripes/components';
 import { FolioFormattedTime } from '@folio/stripes-acq-components';
 
 import {
@@ -37,7 +37,7 @@ const formatData = ({ capability, column, data }) => {
       CUSTOM_ENTITY_COLUMNS.DATE_OF_BIRTH,
       CUSTOM_ENTITY_COLUMNS.ENROLLMENT_DATE
     ].includes(field):
-      return <FormattedUTCDate value={data} />;
+      return dayjs(data).format('MM/DD/YYYY');
     case capability === CAPABILITIES.USER && field === CUSTOM_ENTITY_COLUMNS.USER_STATUS:
       return <FormattedMessage id={`ui-bulk-edit.list.preview.table.status.${data}`} />;
     case [CAPABILITIES.INSTANCE, CAPABILITIES.ITEM].includes(capability) && [

--- a/src/utils/mappers.test.js
+++ b/src/utils/mappers.test.js
@@ -1,4 +1,3 @@
-import { FormattedUTCDate } from '@folio/stripes/components';
 import { FolioFormattedTime } from '@folio/stripes-acq-components';
 
 import { CAPABILITIES, CUSTOM_ENTITY_COLUMNS } from '../constants';
@@ -70,14 +69,14 @@ describe('mappers', () => {
       expect(contentData[0][dateColumn.value].type).toEqual(FolioFormattedTime);
     });
 
-    it('should convert user expiration date string to FormattedUTCDate', () => {
+    it('should format user expiration date using dayjs', () => {
       const expirationColumn = {
         value: CUSTOM_ENTITY_COLUMNS.EXPIRATION_DATE,
         label: CUSTOM_ENTITY_COLUMNS.EXPIRATION_DATE,
         visible: true,
         dataType: DATA_TYPES.DATE_TIME,
       };
-      const row = ['2023-03-18 23:59:59.000Z'];
+      const row = ['2023-03-18'];
       const data = {
         header: [expirationColumn],
         rows: [{ row }],
@@ -85,7 +84,7 @@ describe('mappers', () => {
 
       const { contentData } = getMappedTableData({ data, intl, capabilities: CAPABILITIES.USER });
 
-      expect(contentData[0][expirationColumn.value].type).toEqual(FormattedUTCDate);
+      expect(contentData[0][expirationColumn.value]).toBe('03/18/2023');
     });
 
     it('should not convert date string to FolioFormattedTime when value is empty', () => {


### PR DESCRIPTION
 The previous logic stripped any text in parentheses from note type labels (e.g. Last Check In Date (Sierra) → Last Check In Date). On ECS environments it also replaced the brackets content with the tenant code instead of preserving the original name.                                       
                                                                                                                                                                                                                                                                                                   
  - Root cause: `removeDuplicatesByValue` used a naive `indexOf('(') / indexOf(')')` approach that blindly removed everything between the first pair of brackets - both on non-ECS (stripping meaningful label text) and on ECS Central tenant (replacing it with tenant code).                        
                                                                                                                                                                                                                                                                                                   
✅ Fix: replaced the bracket-stripping logic with a targeted `stripTenantSuffix` helper that only removes the  (tenantCode) suffix when it exactly matches the item's own tenant, leaving any other parenthesised text in the label untouched.      
                                                
  - Date display fix in preview table - remove UTC timezone shift. `FormattedUTCDate` was forcing UTC timezone on date-only fields (Expiration Date, Date of Birth, Enrollment Date. Since the backend already returns dates in the correct local timezone, the forced UTC conversion could shift the displayed date by ±1 day depending on the user's locale.                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                   
✅ Fix: replaced `FormattedUTCDate` with `dayjs(data).format('MM/DD/YYYY')`, which formats the date as provided without any timezone conversion.       

Refs: [UIBULKED-758](https://folio-org.atlassian.net/browse/UIBULKED-758)                                                                                                              