### PR TITLE
UIBULKED-590 Replace "Remove all"  operation on MARC instance edits with "Remove field" and "Remove subfield"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In progress
 
+* [UIBULKED-766](https://folio-org.atlassian.net/browse/UIBULKED-766) Bulk Edit - Support editing material type in item records.
+* [UIBULKED-590](https://folio-org.atlassian.net/browse/UIBULKED-590) Replace "Remove all"  operation on MARC instance edits with "Remove field" and "Remove subfield".
+
 ## [5.1.1](https://github.com/folio-org/ui-bulk-edit/tree/v5.1.1) (2026-05-14)
 
 * [UIBULKED-758](https://folio-org.atlassian.net/browse/UIBULKED-758) Rollback incorrect dates formatting

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/MarcForm/MarcFormBody.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/MarcForm/MarcFormBody.js
@@ -128,7 +128,7 @@ export const MarcFormBody = ({ fields, setFields, isNonInteractive }) => {
                   key={fieldConfig.name}
                   field={fieldConfig}
                   item={item}
-                  ctx={{ index }}
+                  ctx={{ index, actions: item.actions }}
                   errors={errors}
                   rootPath={[index]}
                   onChange={handleChange}

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/MarcForm/MarcFormTitle.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/MarcForm/MarcFormTitle.js
@@ -4,13 +4,16 @@ import { FormattedMessage } from 'react-intl';
 
 import { Col, Icon, Label, Row, Tooltip } from '@folio/stripes/components';
 
+import { ACTIONS } from '../../../../../constants/marcActions';
 import { DATA_KEYS, getFieldWithMaxColumns } from '../helpers';
 
 import css from '../../../BulkEditPane.css';
 
+const SUBFIELD_REQUIRED_ACTIONS = [ACTIONS.ADD_TO_EXISTING, ACTIONS.FIND, ACTIONS.REMOVE_SUBFIELD];
 
 export const MarcFormTitle = ({ fields, isNonInteractive }) => {
   const longestField = getFieldWithMaxColumns(fields);
+  const isSubfieldRequired = fields.some(f => SUBFIELD_REQUIRED_ACTIONS.includes(f.actions?.[0]?.name));
 
   return (
     <Row className={css.row}>
@@ -55,7 +58,7 @@ export const MarcFormTitle = ({ fields, isNonInteractive }) => {
       <Col
         className={`${css.headerCell} ${css.subfield}`}
       >
-        <Label required={!isNonInteractive}>
+        <Label required={!isNonInteractive && isSubfieldRequired}>
           <FormattedMessage id="ui-bulk-edit.layer.column.subfield" />
         </Label>
         <div className={css.splitter} />

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/helpers.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/helpers.js
@@ -84,7 +84,8 @@ export const getNextAction = (action) => {
         data: [],
       };
     case ACTIONS.REMOVE_ALL:
-      // No further action after removing all
+    case ACTIONS.REMOVE_FIELD:
+    case ACTIONS.REMOVE_SUBFIELD:
       return null;
     default:
       return null;
@@ -109,7 +110,8 @@ export const getNextData = (action) => {
         { key: DATA_KEYS.VALUE, value: '' }
       ];
     case ACTIONS.REMOVE_ALL:
-      // Removing all requires no extra data
+    case ACTIONS.REMOVE_FIELD:
+    case ACTIONS.REMOVE_SUBFIELD:
       return [];
     default:
       return [];

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/schema.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/schema.js
@@ -6,12 +6,13 @@ import {
   getAppendAction,
   getFindAction,
   getPlaceholder,
-  getRemoveAllAction,
   getRemoveFieldAction,
   getRemoveSubfieldAction,
   getReplaceWithAction
 } from '../../../../constants/marcActions';
 import { INDICATOR_FIELD_MAX_LENGTH, SUBFIELD_MAX_LENGTH, TAG_FIELD_MAX_LENGTH } from './helpers';
+
+const SUBFIELD_REQUIRED_ACTIONS = [ACTIONS.ADD_TO_EXISTING, ACTIONS.FIND, ACTIONS.REMOVE_SUBFIELD];
 
 export const schema = [
   {
@@ -57,6 +58,7 @@ export const schema = [
     disabled: false,
     showError: true,
     dirty: (value) => !!value?.length,
+    required: ({ actions }) => SUBFIELD_REQUIRED_ACTIONS.includes(actions?.[0]?.name),
   },
   {
     name: 'actions',
@@ -89,7 +91,8 @@ export const schema = [
               getPlaceholder(),
               getAddAction(),
               getFindAction(),
-              getRemoveAllAction(),
+              getRemoveFieldAction(),
+              getRemoveSubfieldAction(),
             ];
           }
 
@@ -107,8 +110,6 @@ export const schema = [
                 getRemoveSubfieldAction(),
                 getReplaceWithAction(),
               ];
-            case ACTIONS.REMOVE_ALL:
-              return null;
             default:
               return null;
           }

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/validation.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/validation.js
@@ -3,6 +3,15 @@ import { array, object, string } from 'yup';
 import { DATA_KEYS, INDICATOR_FIELD_MAX_LENGTH } from './helpers';
 import { ACTIONS } from '../../../../constants/marcActions';
 
+const SUBFIELD_FORMAT_TEST = [
+  'is-valid-subfield',
+  'ui-bulk-edit.layer.marc.error.subfield',
+  value => /^[a-z0-9]+$/.test(value),
+];
+
+// Actions that require the row-level subfield to be populated
+const SUBFIELD_REQUIRED_ACTIONS = [ACTIONS.ADD_TO_EXISTING, ACTIONS.FIND, ACTIONS.REMOVE_SUBFIELD];
+
 /**
  * Schema definition for validating individual subfield entries within a MARC field.
  * Ensures the subfield code and its associated actions conform to expected formats.
@@ -10,11 +19,7 @@ import { ACTIONS } from '../../../../constants/marcActions';
 const subfieldSchema = {
   subfield: string()
     .required()
-    .test(
-      'is-valid-subfield',
-      'ui-bulk-edit.layer.marc.error.subfield',
-      value => /^[a-z0-9]+$/.test(value), // Only lowercase alphanumeric characters allowed
-    ),
+    .test(...SUBFIELD_FORMAT_TEST),
 
   actions: array()
     .of(
@@ -100,7 +105,12 @@ export const validationSchema = array(
         value => latinRegex.test(value)
       ),
     subfields: array(object(subfieldSchema)).nullable(),
-    ...subfieldSchema,
+    subfield: string().when('actions', {
+      is: (actions) => SUBFIELD_REQUIRED_ACTIONS.includes(actions?.[0]?.name),
+      then: (schema) => schema.required().test(...SUBFIELD_FORMAT_TEST),
+      otherwise: (schema) => schema,
+    }),
+    actions: subfieldSchema.actions,
   }).test(
     'tag-999',
     'ui-bulk-edit.layer.marc.error.protected',

--- a/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/validation.test.js
+++ b/src/components/BulkEditPane/BulkEditListResult/BulkEditMarc/validation.test.js
@@ -142,6 +142,94 @@ describe('getMarcFormErrors', () => {
     });
   });
 
+  it('should not require subfield when action is Remove field', () => {
+    const input = [
+      {
+        id: '202',
+        tag: '500',
+        ind1: '\\',
+        ind2: '\\',
+        subfield: '',
+        actions: [
+          {
+            name: ACTIONS.REMOVE_FIELD,
+            data: [],
+          },
+        ],
+        subfields: [],
+      },
+    ];
+
+    const errors = getFormErrors(input, validationSchema);
+    expect(errors).toEqual({});
+  });
+
+  it('should require subfield when action is Remove subfield and subfield is empty', () => {
+    const input = [
+      {
+        id: '202',
+        tag: '500',
+        ind1: '\\',
+        ind2: '\\',
+        subfield: '',
+        actions: [
+          {
+            name: ACTIONS.REMOVE_SUBFIELD,
+            data: [],
+          },
+        ],
+        subfields: [],
+      },
+    ];
+
+    const errors = getFormErrors(input, validationSchema);
+    expect(errors['[0].subfield']).toBe('ui-bulk-edit.layer.marc.error.subfield');
+  });
+
+  it('should pass when action is Remove subfield and subfield is filled', () => {
+    const input = [
+      {
+        id: '202',
+        tag: '500',
+        ind1: '\\',
+        ind2: '\\',
+        subfield: 'a',
+        actions: [
+          {
+            name: ACTIONS.REMOVE_SUBFIELD,
+            data: [],
+          },
+        ],
+        subfields: [],
+      },
+    ];
+
+    const errors = getFormErrors(input, validationSchema);
+    expect(errors).toEqual({});
+  });
+
+  it('should not require subfield when no action is selected', () => {
+    const input = [
+      {
+        id: '202',
+        tag: '500',
+        ind1: '\\',
+        ind2: '\\',
+        subfield: '',
+        actions: [
+          {
+            name: '',
+            data: [],
+          },
+        ],
+        subfields: [],
+      },
+    ];
+
+    const errors = getFormErrors(input, validationSchema);
+    expect(errors['[0].subfield']).toBeUndefined();
+  });
+
   it('should return errors when second action is required', () => {
     const invalidInput = [
       {

--- a/src/components/BulkEditPane/BulkEditMarcLayer/BulkEditMarcLayer.test.js
+++ b/src/components/BulkEditPane/BulkEditMarcLayer/BulkEditMarcLayer.test.js
@@ -332,7 +332,7 @@ describe('BulkEditMarcLayer', () => {
     await act(async () => {
       await userEvent.type(inputField, '555');
       await userEvent.type(inputSubField, 'a');
-      await userEvent.selectOptions(actionSelect, ACTIONS.REMOVE_ALL);
+      await userEvent.selectOptions(actionSelect, ACTIONS.REMOVE_FIELD);
     });
 
     const confirmChangesBtn = getByRole('button', { name: /confirmChanges/i });

--- a/src/constants/marcActions.js
+++ b/src/constants/marcActions.js
@@ -70,5 +70,6 @@ export const marcActions = () => [
   getPlaceholder(),
   getAddAction(),
   getFindAction(),
-  getRemoveAllAction(),
+  getRemoveFieldAction(),
+  getRemoveSubfieldAction(),
 ];


### PR DESCRIPTION
The current `Remove all` behavior in Bulk Edit for MARC-sourced instances is unintuitive: the Subfield column was always marked as required, so users had to enter a subfield even when they only wanted to remove an entire field. There was also no way to remove only a subfield while keeping the field.

This PR clarifies when Subfield is actually required and splits the ambiguous "Remove all" option into two explicit operations:
`Remove field` - removes the whole MARC field; Subfield is not required.
`Remove subfield` - removes only the specified subfield; Subfield is required.

<img width="2558" height="516" alt="image" src="https://github.com/user-attachments/assets/6fc8c1da-5869-4a50-b7d1-4fa87dfcf8fe" />

Refs: [UIBULKED-590](https://folio-org.atlassian.net/browse/UIBULKED-590)