### PR TITLE
UIBULKED-99 User records bulk delete authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIBULKED-766](https://folio-org.atlassian.net/browse/UIBULKED-766) Bulk Edit - Support editing material type in item records.
 * [UIBULKED-590](https://folio-org.atlassian.net/browse/UIBULKED-590) Replace "Remove all"  operation on MARC instance edits with "Remove field" and "Remove subfield".
+* [UIBULKED-99](https://folio-org.atlassian.net/browse/UIBULKED-99) User records bulk delete authorization.
 
 ## [5.1.1](https://github.com/folio-org/ui-bulk-edit/tree/v5.1.1) (2026-05-14)
 

--- a/package.json
+++ b/package.json
@@ -189,6 +189,14 @@
         "visible": true
       },
       {
+        "permissionName": "ui-bulk-edit.users.delete",
+        "displayName": "Bulk edit: In app - Delete user records",
+        "subPermissions": [
+          "ui-bulk-edit.users.edit"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-bulk-edit.logs.view",
         "displayName": "Bulk edit: Can view logs",
         "subPermissions": [

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.js
@@ -56,6 +56,7 @@ const BulkEditActionMenu = ({
     hasHoldingsInventoryEdit,
     hasItemInventoryEdit,
     hasUserEditInAppPerm,
+    hasUserDeleteInAppPerm,
     hasInstanceInventoryEdit,
     hasInstanceAndMarcEditPerm,
     hasInventoryAndMarcEditPerm,
@@ -77,12 +78,19 @@ const BulkEditActionMenu = ({
   const isECS = stripes.user?.user?.consortium;
   const isStartBulkCsvActive = hasUserEditLocalPerm && currentRecordType === CAPABILITIES.USER;
   const isInitialStep = step === EDITING_STEPS.UPLOAD;
+  const isStatusActive = [JOB_STATUSES.DATA_MODIFICATION, JOB_STATUSES.REVIEW_CHANGES, JOB_STATUSES.REVIEWED_NO_MARC_RECORDS].includes(bulkDetails?.status);
   const isStartBulkInAppActive =
        hasEditPerm
     && isInitialStep
-    && [JOB_STATUSES.DATA_MODIFICATION, JOB_STATUSES.REVIEW_CHANGES, JOB_STATUSES.REVIEWED_NO_MARC_RECORDS].includes(bulkDetails?.status);
+    && isStatusActive;
   const isStartMarcActive = (isStartBulkInAppActive || hasInstanceAndMarcEditPerm || hasInventoryAndMarcEditPerm) && currentRecordType === CAPABILITIES.INSTANCE && isInitialStep
-  && [JOB_STATUSES.DATA_MODIFICATION, JOB_STATUSES.REVIEW_CHANGES, JOB_STATUSES.REVIEWED_NO_MARC_RECORDS].includes(bulkDetails?.status);
+  && isStatusActive;
+
+  const isStartBulkDeleteActive =
+       hasUserDeleteInAppPerm
+    && currentRecordType === CAPABILITIES.USER
+    && isInitialStep
+    && isStatusActive;
 
   const isStartManualButtonVisible = isStartBulkCsvActive && isInitialStep && countOfRecords > 0 && criteria !== CRITERIA.QUERY && !isECS;
 
@@ -228,6 +236,17 @@ const BulkEditActionMenu = ({
           >
             <Icon icon="edit">
               <FormattedMessage id="ui-bulk-edit.start.edit.csv" />
+            </Icon>
+          </Button>
+        )}
+        {isStartBulkDeleteActive && (
+          <Button
+            data-testid="startBulkDeleteAction"
+            buttonStyle="dropdownItem"
+            onClick={() => handleOnStartEdit(APPROACHES.DELETE)}
+          >
+            <Icon icon="trash">
+              <FormattedMessage id="ui-bulk-edit.start.delete" />
             </Icon>
           </Button>
         )}

--- a/src/components/BulkEditActionMenu/BulkEditActionMenu.test.js
+++ b/src/components/BulkEditActionMenu/BulkEditActionMenu.test.js
@@ -3,7 +3,7 @@ import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClientProvider } from 'react-query';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import { useOkapiKy, useStripes } from '@folio/stripes/core';
 
 import '../../../test/jest/__mock__';
 import { runAxeTest } from '@folio/stripes-testing';
@@ -94,6 +94,7 @@ describe('BulkEditActionMenu', () => {
     useBulkOperationDetails.mockClear().mockReturnValue({ bulkDetails: bulkOperation });
 
     useOkapiKy.mockClear().mockReturnValue({});
+    useStripes().hasPerm.mockReturnValue(true);
   });
 
   it('should display actions group', async () => {
@@ -195,6 +196,66 @@ describe('BulkEditActionMenu', () => {
     await userEvent.click(screen.getByTestId('startCsvAction'));
 
     expect(onEdit).toHaveBeenCalledWith(APPROACHES.MANUAL);
+    expect(onToggle).toHaveBeenCalled();
+  });
+
+  it('should display start bulk delete action when user has both bulk delete and users delete permissions', () => {
+    renderBulkEditActionMenu({
+      step: EDITING_STEPS.UPLOAD,
+      capability: CAPABILITIES.USER,
+      providerState: { ...defaultProviderState, visibleColumns: [] },
+    });
+
+    expect(screen.getByTestId('startBulkDeleteAction')).toBeVisible();
+  });
+
+  it('should hide start bulk delete action when functional users delete permission is missing', () => {
+    useStripes().hasPerm.mockImplementation((perm) => perm !== 'ui-users.delete');
+
+    renderBulkEditActionMenu({
+      step: EDITING_STEPS.UPLOAD,
+      capability: CAPABILITIES.USER,
+      providerState: { ...defaultProviderState, visibleColumns: [] },
+    });
+
+    expect(screen.queryByTestId('startBulkDeleteAction')).not.toBeInTheDocument();
+  });
+
+  it('should hide start bulk delete action when bulk delete permission is missing', () => {
+    useStripes().hasPerm.mockImplementation((perm) => perm !== 'ui-bulk-edit.users.delete');
+
+    renderBulkEditActionMenu({
+      step: EDITING_STEPS.UPLOAD,
+      capability: CAPABILITIES.USER,
+      providerState: { ...defaultProviderState, visibleColumns: [] },
+    });
+
+    expect(screen.queryByTestId('startBulkDeleteAction')).not.toBeInTheDocument();
+  });
+
+  it('should not display start bulk delete action for non-user record types', () => {
+    renderBulkEditActionMenu({
+      step: EDITING_STEPS.UPLOAD,
+      capability: CAPABILITIES.ITEM,
+      providerState: { ...defaultProviderState, visibleColumns: [] },
+    });
+
+    expect(screen.queryByTestId('startBulkDeleteAction')).not.toBeInTheDocument();
+  });
+
+  it('should start bulk delete when the delete action is clicked', async () => {
+    onEdit.mockClear();
+    onToggle.mockClear();
+
+    renderBulkEditActionMenu({
+      step: EDITING_STEPS.UPLOAD,
+      capability: CAPABILITIES.USER,
+      providerState: { ...defaultProviderState, visibleColumns: [] },
+    });
+
+    await userEvent.click(screen.getByTestId('startBulkDeleteAction'));
+
+    expect(onEdit).toHaveBeenCalledWith(APPROACHES.DELETE);
     expect(onToggle).toHaveBeenCalled();
   });
 

--- a/src/hooks/useBulkPermissions.js
+++ b/src/hooks/useBulkPermissions.js
@@ -11,6 +11,7 @@ export const useBulkPermissions = () => {
   const hasInAppViewPerms = stripes.hasPerm('ui-bulk-edit.inventory.view');
   const hasInAppEditPerms = stripes.hasPerm('ui-bulk-edit.inventory.edit');
   const hasInAppUsersEditPerms = stripes.hasPerm('ui-bulk-edit.users.edit');
+  const hasInAppUsersDeletePerms = stripes.hasPerm('ui-bulk-edit.users.delete');
 
   // Query perms
   const hasQueryPerms = stripes.hasPerm('ui-bulk-edit.query.execute');
@@ -29,6 +30,7 @@ export const useBulkPermissions = () => {
   // Users
   const hasUsersPerms = stripes.hasPerm('ui-users.edit');
   const hasUsersViewPerms = stripes.hasPerm('ui-users.view');
+  const hasUsersDeletePerms = stripes.hasPerm('ui-users.delete');
 
   // derived pages
   const hasAnyInAppEditPermissions = hasInAppEditPerms || hasInAppUsersEditPerms;
@@ -53,6 +55,7 @@ export const useBulkPermissions = () => {
   const hasOnlyViewInventoryAndMarcPerms = hasInventoryInstanceViewPerms && hasQuickMarcViewPerms;
   const hasUserEditLocalPerm = hasCsvEditPerms && hasUsersPerms;
   const hasUserEditInAppPerm = hasInAppUsersEditPerms && hasUsersPerms;
+  const hasUserDeleteInAppPerm = hasInAppUsersDeletePerms && hasUsersDeletePerms;
   const hasAnyEditPermissions = hasAnyUserWithBulkPerm || hasAnyInventoryWithInAppView;
   const isSelectIdentifiersDisabled = !hasAnyEditPermissions;
   const isDropZoneDisabled = !hasAnyEditPermissions;
@@ -77,6 +80,7 @@ export const useBulkPermissions = () => {
     hasInAppViewPerms,
     hasInAppEditPerms,
     hasInAppUsersEditPerms,
+    hasInAppUsersDeletePerms,
     hasLogViewPerms,
     hasQueryPerms,
     hasInventoryInstanceViewPerms,
@@ -98,6 +102,7 @@ export const useBulkPermissions = () => {
     hasHoldingsPerms,
     hasUsersPerms,
     hasUsersViewPerms,
+    hasUsersDeletePerms,
     hasOnlyViewCsvPerms,
     hasViewInAppPerms,
     hasItemInventoryEdit,
@@ -112,6 +117,7 @@ export const useBulkPermissions = () => {
     hasAnyUserWithBulkPerm,
     hasUserEditLocalPerm,
     hasUserEditInAppPerm,
+    hasUserDeleteInAppPerm,
     hasLogInstanceViewPerms,
     hasInstanceInventoryEdit,
     hasInstanceInventoryView,


### PR DESCRIPTION
Introduce a new Bulk edit Delete user records authorization and gate the Start bulk delete action behind it, so the action is shown only to operators who can delete user records in both the Bulk edit and Users apps.

<img width="2555" height="1319" alt="image" src="https://github.com/user-attachments/assets/fe81b938-9674-4a73-aeed-b6d43aa2d419" />

Refs: [UIBULKED-99](https://folio-org.atlassian.net/browse/UIBULKED-99)