### PR TITLE
UIBULKED-767 Bulk edit logs for bulk deletion - support downloading the triggering query file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [UIBULKED-99](https://folio-org.atlassian.net/browse/UIBULKED-99) User records bulk delete authorization.
 * [UIBULKED-26](https://folio-org.atlassian.net/browse/UIBULKED-26) Bulk delete user records - Delete user records? form.
 * [UIBULKED-27](https://folio-org.atlassian.net/browse/UIBULKED-27) Confirmation form - Error accordion.
+* [UIBULKED-28](https://folio-org.atlassian.net/browse/UIBULKED-28) Bulk edit logs for bulk deletion - support downloading the triggering query file.
 
 ## [5.1.1](https://github.com/folio-org/ui-bulk-edit/tree/v5.1.1) (2026-05-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * [UIBULKED-99](https://folio-org.atlassian.net/browse/UIBULKED-99) User records bulk delete authorization.
 * [UIBULKED-26](https://folio-org.atlassian.net/browse/UIBULKED-26) Bulk delete user records - Delete user records? form.
 * [UIBULKED-27](https://folio-org.atlassian.net/browse/UIBULKED-27) Confirmation form - Error accordion.
-* [UIBULKED-28](https://folio-org.atlassian.net/browse/UIBULKED-28) Bulk edit logs for bulk deletion - support downloading the triggering query file.
+* [UIBULKED-767](https://folio-org.atlassian.net/browse/UIBULKED-767) Bulk edit logs for bulk deletion - support downloading the triggering query file.
 
 ## [5.1.1](https://github.com/folio-org/ui-bulk-edit/tree/v5.1.1) (2026-05-14)
 

--- a/src/components/BulkEditLogs/BulkEditLogsActions/BulkEditLogsActions.test.js
+++ b/src/components/BulkEditLogs/BulkEditLogsActions/BulkEditLogsActions.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@folio/jest-config-stripes/testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@folio/jest-config-stripes/testing-library/react';
 import { QueryClientProvider } from 'react-query';
 import { useOkapiKy } from '@folio/stripes/core';
 import '../../../../test/jest/__mock__';
@@ -12,6 +12,7 @@ import { queryClient } from '../../../../test/jest/utils/queryClient';
 import {
   JOB_STATUSES,
   FILE_KEYS,
+  FILE_SEARCH_PARAMS,
   CAPABILITIES,
   LINK_KEYS,
 } from '../../../constants';
@@ -102,5 +103,16 @@ describe('BulkEditLogsActions', () => {
 
       expect(screen.getByTestId(fileKey)).toBeDefined();
     });
+  });
+
+  it('should download the triggering query file with the TRIGGERING_QUERY_FILE content type', async () => {
+    renderBulkEditLogsActions();
+
+    fireEvent.click(screen.getByTestId(FILE_KEYS.TRIGGERING_QUERY_FILE));
+
+    await waitFor(() => expect(mockRefetch).toHaveBeenCalled());
+
+    const lastCallArgs = useFileDownload.mock.calls.at(-1)[0];
+    expect(lastCallArgs.fileContentType).toBe(FILE_SEARCH_PARAMS.TRIGGERING_QUERY_FILE);
   });
 });

--- a/src/constants/files.js
+++ b/src/constants/files.js
@@ -5,6 +5,7 @@ import { EDITING_STEPS } from './core';
 // use as API key for /download
 export const FILE_SEARCH_PARAMS = {
   TRIGGERING_FILE: 'TRIGGERING_FILE',
+  TRIGGERING_QUERY_FILE: 'TRIGGERING_QUERY_FILE',
   MATCHED_RECORDS_FILE: 'MATCHED_RECORDS_FILE',
   RECORD_MATCHING_ERROR_FILE: 'RECORD_MATCHING_ERROR_FILE',
   COMMITTED_RECORDS_FILE: 'COMMITTED_RECORDS_FILE',
@@ -17,6 +18,7 @@ export const FILE_SEARCH_PARAMS = {
 // use as marks that getFileName are ready
 export const FILE_KEYS = {
   TRIGGERING_FILE: 'linkToTriggeringCsvFile',
+  TRIGGERING_QUERY_FILE: 'linkToTriggeringQueryFile',
   MATCHED_RECORDS_FILE: 'linkToMatchedRecordsCsvFile',
   RECORD_MATCHING_ERROR_FILE: 'linkToMatchedRecordsErrorsCsvFile',
   COMMITTED_RECORDS_FILE: 'linkToCommittedRecordsCsvFile',
@@ -28,6 +30,7 @@ export const FILE_KEYS = {
 
 export const LINK_KEYS = {
   linkToTriggeringCsvFile: FILE_SEARCH_PARAMS.TRIGGERING_FILE,
+  linkToTriggeringQueryFile: FILE_SEARCH_PARAMS.TRIGGERING_QUERY_FILE,
   linkToMatchedRecordsCsvFile: FILE_SEARCH_PARAMS.MATCHED_RECORDS_FILE,
   linkToMatchedRecordsErrorsCsvFile: FILE_SEARCH_PARAMS.RECORD_MATCHING_ERROR_FILE,
   linkToModifiedRecordsCsvFile: FILE_SEARCH_PARAMS.PROPOSED_CHANGES_FILE,

--- a/translations/ui-bulk-edit/en.json
+++ b/translations/ui-bulk-edit/en.json
@@ -496,6 +496,7 @@
   "logs.actions.linkToCommittedRecordsMarcFile": "File with updated records (MARC)",
   "logs.actions.linkToCommittedRecordsErrorsCsvFile": "File with errors encountered when committing the changes",
   "logs.actions.linkToTriggeringCsvFile.QUERY": "File with identifiers of the records affected by bulk update",
+  "logs.actions.linkToTriggeringQueryFile.QUERY": "File with the query used to trigger the bulk edit",
   "logs.actions.linkToMatchedRecordsCsvFile.QUERY": "File with the matching records",
   "logs.actions.linkToMatchedRecordsErrorsCsvFile.QUERY": "File with errors encountered during the record matching",
   "logs.actions.linkToModifiedRecordsCsvFile.QUERY": "File with the preview of proposed changes (CSV)",


### PR DESCRIPTION
Surface the new bulk-deletion query file (`linkToTriggeringQueryFile` / `TRIGGERING_QUERY_FILE`, added by BE in the Logs download menu.

<img width="2557" height="746" alt="image" src="https://github.com/user-attachments/assets/05e89ad5-3d75-4853-bf20-6ffb7ff20b9e" />

Refs: [UIBULKED-767](https://folio-org.atlassian.net/browse/UIBULKED-767)